### PR TITLE
CI: add initial pass at Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: build
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: seanmiddleditch/gha-setup-vsdevenv@master
+
+      - name: Configure
+        run: cmake -B ${{ github.workspace }}/out -D CMAKE_BUILD_TYPE=Release -G Ninja -S ${{ github.workspace }}
+      - name: Build
+        run: cmake --build ${{ github.workspace }}/out --config Release


### PR DESCRIPTION
Use GitHub Actions to try to configure CI for various targets.  Add an
initial build for Windows as a quick and dirty test as this is the more
complicated platform.