### PR TITLE
build: use global CMake settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ cmake_policy(SET CMP0054 NEW)
 
 project(DebugServer2)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS NO)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(OS_NAME ${CMAKE_SYSTEM_NAME})
@@ -317,9 +320,6 @@ else ()
   add_executable(ds2 ${DEBUGSERVER2_SOURCES})
 endif ()
 target_include_directories(ds2 PUBLIC Headers)
-set_property(TARGET ds2 PROPERTY CXX_STANDARD 11)
-set_property(TARGET ds2 PROPERTY CXX_EXTENSIONS OFF)
-set_property(TARGET ds2 PROPERTY CXX_STANDARD_REQUIRED ON)
 
 execute_process(COMMAND git rev-parse --short HEAD
                 WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/Tools/JSObjects/CMakeLists.txt
+++ b/Tools/JSObjects/CMakeLists.txt
@@ -41,8 +41,7 @@ target_include_directories(jsobjects
                            PRIVATE ${JSObjects_BINARY_DIR})
 set_property(TARGET jsobjects PROPERTY C_STANDARD 99)
 set_property(TARGET jsobjects PROPERTY C_EXTENSIONS OFF)
-set_property(TARGET jsobjects PROPERTY CXX_STANDARD 11)
-set_property(TARGET jsobjects PROPERTY CXX_EXTENSIONS OFF)
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
     (CMAKE_CXX_COMPILER_ID MATCHES "Clang" 
     AND NOT CMAKE_CXX_SIMULATE_ID MATCHES "MSVC"))

--- a/Tools/RegsGen2/CMakeLists.txt
+++ b/Tools/RegsGen2/CMakeLists.txt
@@ -24,7 +24,6 @@ set(REGSGEN2_SOURCES
     )
 
 add_executable(regsgen2 ${REGSGEN2_SOURCES})
-set_property(TARGET regsgen2 PROPERTY CXX_STANDARD 11)
 target_compile_options(regsgen2 PRIVATE -Wall -Wextra -Wno-unused-parameter -Wno-unused-function)
 
 add_subdirectory(../JSObjects "${CMAKE_CURRENT_BINARY_DIR}/JSObjects")


### PR DESCRIPTION
Use the global C++ standards for the project rather than individually
setting the properties on the targets.