### PR TITLE
build: specify languages for projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@
 cmake_minimum_required(VERSION 3.9)
 cmake_policy(SET CMP0054 NEW)
 
-project(DebugServer2)
+project(DebugServer2
+  LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS NO)
@@ -390,12 +391,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
 
   function(enable_warning TARGET FLAG)
     string(REGEX REPLACE "[-/ ]" "" TAG "${FLAG}")
-
-    CHECK_C_COMPILER_FLAG("${FLAG}" ${TAG}_FLAG_AVAILABLE_C)
-    if (${TAG}_FLAG_AVAILABLE_C)
-      target_compile_options("${TARGET}" PRIVATE
-          $<$<COMPILE_LANGUAGE:C>:${FLAG}>)
-    endif ()
 
     CHECK_CXX_COMPILER_FLAG("${FLAG}" "${TAG}_FLAG_AVAILABLE_CXX")
     if (${TAG}_FLAG_AVAILABLE_CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.9)
 cmake_policy(SET CMP0054 NEW)
 
 project(DebugServer2
-  LANGUAGES CXX)
+  LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS NO)
@@ -391,6 +391,12 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
 
   function(enable_warning TARGET FLAG)
     string(REGEX REPLACE "[-/ ]" "" TAG "${FLAG}")
+
+    CHECK_C_COMPILER_FLAG("${FLAG}" ${TAG}_FLAG_AVAILABLE_C)
+    if (${TAG}_FLAG_AVAILABLE_C)
+      target_compile_options("${TARGET}" PRIVATE
+          $<$<COMPILE_LANGUAGE:C>:${FLAG}>)
+    endif ()
 
     CHECK_CXX_COMPILER_FLAG("${FLAG}" "${TAG}_FLAG_AVAILABLE_CXX")
     if (${TAG}_FLAG_AVAILABLE_CXX)

--- a/Tools/JSObjects/CMakeLists.txt
+++ b/Tools/JSObjects/CMakeLists.txt
@@ -10,7 +10,16 @@
 
 cmake_minimum_required(VERSION 3.3)
 
-project(JSObjects)
+project(JSObjects
+  LANGUAGES C CXX)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_EXTENSIONS NO)
+set(CMAKE_C_STANDARD_REQUIRED YES)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS NO)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_package(BISON)
 find_package(FLEX)
@@ -39,8 +48,6 @@ target_include_directories(jsobjects
                            PUBLIC ${JSObjects_SOURCE_DIR}/Headers
                            PRIVATE ${JSObjects_SOURCE_DIR}/Sources/libjson
                            PRIVATE ${JSObjects_BINARY_DIR})
-set_property(TARGET jsobjects PROPERTY C_STANDARD 99)
-set_property(TARGET jsobjects PROPERTY C_EXTENSIONS OFF)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
     (CMAKE_CXX_COMPILER_ID MATCHES "Clang" 

--- a/Tools/RegsGen2/CMakeLists.txt
+++ b/Tools/RegsGen2/CMakeLists.txt
@@ -10,7 +10,12 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
-project(RegsGen2)
+project(RegsGen2
+  LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS NO)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 set(REGSGEN2_SOURCES
     FlagSet.cpp


### PR DESCRIPTION
Explicitly specify the languages the projects use and use the global language
standard specification.