### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         run: cmake --build ${{ github.workspace }}/out --config Release
-        
+
   macos:
     runs-on: macos-latest
 
@@ -45,7 +45,8 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           sudo apt-get install -qq --no-install-recommends flex bison ninja-build
+
       - name: Configure
-        run: cmake -B ${{ github.workspace }}/out -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ -G Ninja -S ${{ github.workspace }}
+        run: cmake -B ${{ github.workspace }}/out -D CMAKE_BUILD_TYPE=Release -G Ninja -S ${{ github.workspace }}
       - name: Build
         run: cmake --build ${{ github.workspace }}/out --config Releaase


### PR DESCRIPTION
Use GCC on Linux.  This gives us better compiler coverage as we now use GCC, clang, and MSVC for the CI.