### PR TITLE
POSIX: add some casts for `-Werror=sign-compare`

### DIFF
--- a/Sources/Host/POSIX/File.cpp
+++ b/Sources/Host/POSIX/File.cpp
@@ -71,7 +71,7 @@ ErrorCode File::pread(ByteVector &buf, uint64_t &count, uint64_t offset) {
     return _lastError = kErrorInvalidHandle;
   }
 
-  if (offset > std::numeric_limits<off_t>::max()) {
+  if (static_cast<off_t>(offset) > std::numeric_limits<off_t>::max()) {
     return _lastError = kErrorInvalidArgument;
   }
 
@@ -100,7 +100,7 @@ ErrorCode File::pwrite(ByteVector const &buf, uint64_t &count,
     return _lastError = kErrorInvalidHandle;
   }
 
-  if (offset > std::numeric_limits<off_t>::max()) {
+  if (static_cast<off_t>(offset) > std::numeric_limits<off_t>::max()) {
     return _lastError = kErrorInvalidArgument;
   }
 


### PR DESCRIPTION
When building with gcc 9, the signed comparisons here prevent building.  Add
some `static_cast`s  to deal with the type conversion.