### PR TITLE
Host: repair the build with `-Werror=stringop-truncation`

### DIFF
--- a/Sources/Host/Common/Socket.cpp
+++ b/Sources/Host/Common/Socket.cpp
@@ -210,13 +210,14 @@ bool Socket::listen(std::string const &path, bool abstract) {
       _lastError = SOCK_NAMETOOLONG;
       return false;
     }
-    ::strncpy(sun.sun_path + 1, path.c_str(), sizeof(sun.sun_path) - 1);
+    sun.sun_path[0] = '\0';
+    memcpy(sun.sun_path + 1, path.data(), sizeof(sun.sun_path) - 1);
   } else {
     if (path.length() > sizeof(sun.sun_path)) {
       _lastError = SOCK_NAMETOOLONG;
       return false;
     }
-    ::strncpy(sun.sun_path, path.c_str(), sizeof(sun.sun_path));
+    memcpy(sun.sun_path, path.data(), sizeof(sun.sun_path));
   }
 
   size_t len = offsetof(struct sockaddr_un, sun_path) + path.length() +

--- a/Sources/Host/Linux/ProcFS.cpp
+++ b/Sources/Host/Linux/ProcFS.cpp
@@ -351,7 +351,7 @@ bool ProcFS::ReadStat(pid_t pid, pid_t tid, Stat &stat) {
         // Yes, save the "tcomm" field, and advance field index.
         //
         comm = comm.substr(0, comm.rfind(')'));
-        strncpy(stat.tcomm, comm.c_str(), sizeof(stat.tcomm));
+        memcpy(stat.tcomm, comm.data(), sizeof(stat.tcomm));
         field_index++;
       } else {
         if (!may_end_comm) {


### PR DESCRIPTION
When building with GCC 9.3, the `strncpy` is flagged as a possible truncation as
we use the size of the destination for the `strncpy` which expects space for the
trailing nul.  However, we are working with a fixed size buffer, and so prefer
the use of `memcpy` instead.

Take the opportunity to explicitly write the leading nul-character for the unix
path.