### PR TITLE
Target: repair the build for `-Werror=maybe-uninitialized`

### DIFF
--- a/Sources/Target/Linux/Process.cpp
+++ b/Sources/Target/Linux/Process.cpp
@@ -180,7 +180,7 @@ ErrorCode Process::wait() {
   // We have at least one thread when we start waiting on a process.
   DS2ASSERT(!_threads.empty());
 
-  while (!_threads.empty()) {
+  do {
     tid = blocking_waitpid(-1, &status, __WALL);
     if (tid <= 0) {
       return kErrorProcessNotFound;
@@ -323,7 +323,7 @@ ErrorCode Process::wait() {
   continue_waiting:
     _currentThread = nullptr;
     continue;
-  }
+  } while (!_threads.empty());
 
   if (!(WIFEXITED(status) || WIFSIGNALED(status)) || tid != _pid) {
     //


### PR DESCRIPTION
When building with GCC 9.3, the following maybe uninitialized path is identified:

~~~
Sources/Target/Linux/Process.cpp: In member function ‘virtual ds2::ErrorCode ds2::Target::Linux::Process::wait()’:
Sources/Target/Linux/Process.cpp:328:51: error: ‘tid’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  328 |   if (!(WIFEXITED(status) || WIFSIGNALED(status)) || tid != _pid) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
~~~

Although the `DS2ASSERT` exists above the loop, gcc does not propagate the
information through LICM which results in the path being misflagged.  Convert to
`do { } while` instead of `while { }` to indicate that we expect at least one
iteration through the loop.