### PR TITLE
build: remove `-rdynamic` hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
   # be set before we include subdirectories.
   if (STATIC)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-  else ()
-    # Export symbols, so that we can symbolicate backtraces
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
   endif ()
 
   if (SANITIZER)


### PR DESCRIPTION
This breaks the build on MinGW currently.  Furthermore, this is a horrible
workaround.  We should simply build with debug information and symbolicate with
the debug information.