### PR TITLE
Target: repair `-Werror=implicit-fallthrough`

### DIFF
--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -177,6 +177,7 @@ void Thread::updateState(DEBUG_EVENT const &de) {
     default:
       DS2LOG(Warning, "unsupported exception code: %lx",
              de.u.Exception.ExceptionRecord.ExceptionCode);
+      [[gnu::fallthrough]];
 
     case STATUS_INVALID_DISPOSITION:
     case STATUS_NONCONTINUABLE_EXCEPTION:


### PR DESCRIPTION
Annotate the switch with a fallthrough to indicate that it is expected.  This
repairs the build with `-Wrror=implicit-fallthrough`.

~~~
Sources/Target/Windows/Thread.cpp: In member function 'virtual void ds2::Target::Windows::Thread::updateState(const DEBUG_EVENT&)':
Headers/DebugServer2/Utils/Log.h:62:11: error: this statement may fall through [-Werror=implicit-fallthrough=]
   62 |   ds2::Log(ds2::kLogLevel##LVL, nullptr, FUNCTION_NAME, __VA_ARGS__)
      |   ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Sources/Target/Windows/Thread.cpp:178:7: note: in expansion of macro 'DS2LOG'
  178 |       DS2LOG(Warning, "unsupported exception code: %lx",
      |       ^~~~~~
Sources/Target/Windows/Thread.cpp:181:5: note: here
  181 |     case STATUS_INVALID_DISPOSITION:
      |     ^~~~
~~~