### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,9 @@ jobs:
       matrix:
         include: [
           { msystem: ucrt64, prefix: mingw-w64-ucrt-x86_64 },
-          { msystem: clang64, prefix: mingw-w64-clang-x86_64 },
+          # disable clang64 as the packaging seems incorrect:
+          # ...: error while loading shared libraries: librhash.dll: cannot open shared object file: No such file or directory
+          # { msystem: clang64, prefix: mingw-w64-clang-x86_64 },
         ]
     
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,10 @@ jobs:
     strategy:
       fast-fail: false
       matrix:
-        include:
-          - { msystem: ucrt64, prefix: mingw-w64-ucrt-x86_64 },
-          - { msystem: clang64, prefix: mingw-w64-clang-x86_64 },
+        include: [
+          { msystem: ucrt64, prefix: mingw-w64-ucrt-x86_64 },
+          { msystem: clang64, prefix: mingw-w64-clang-x86_64 },
+        ]
     
     steps:
       - uses: msys2/setup-msys2@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         shell: msys2 {0}
 
     strategy:
-      fast-fail: false
+      fail-fast: false
       matrix:
         include: [
           { msystem: ucrt64, prefix: mingw-w64-ucrt-x86_64 },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,19 +33,22 @@ jobs:
         shell: msys2 {0}
 
     strategy:
+      fast-fail: false
       matrix:
-        system: ['mingw64'] # mingw32
+        include:
+          - { msystem: ucrt64, prefix: mingw-w64-ucrt-x86_64 },
+          - { msystem: clang64, prefix: mingw-w64-clang-x86_64 },
     
     steps:
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: ${{ matrix.system }}
+          msystem: ${{ matrix.msystem }}
           install: >-
             flex
             bison
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-ninja
+            ${{ matrix.prefix }}-cmake
+            ${{ matrix.prefix }}-gcc
+            ${{ matrix.prefix }}-ninja
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Update to ucrt64 and clang64 for MinGW.  This targets a newer Windows environment and gives us a build with gcc and clang on MinGW.