### PR TITLE
DebugServer2: ensure that we have a valid SID before use

### DIFF
--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -235,24 +235,22 @@ struct HostInfo {
 
 #if defined(OS_WIN32)
 namespace {
-inline AllocateAndCopySid(const PSID pSid, PSID *ppSid) noexcept {
-  if (!IsValidSid(pSid)) {
-    CreateWellKnownSid(WinNullSid, nullptr, ppSid, nullptr);
-    return;
-  }
+inline BOOL AllocateAndCopySid(const PSID pSid, PSID *ppSid) noexcept {
+  if (!IsValidSid(pSid))
+    return CreateWellKnownSid(WinNullSid, nullptr, ppSid, nullptr);
 
   DWORD nSubAuthorityCount = *GetSidSubAuthorityCount(pSid);
-  AllocateAndInitializeSid(GetSidIdentifierAuthority(pSid),
-                           nSubAuthorityCount,
-                           nSubAuthorityCount > 0 ? *GetSidSubAuthority(pSid, 0) : 0,
-                           nSubAuthorityCount > 1 ? *GetSidSubAuthority(pSid, 1) : 0,
-                           nSubAuthorityCount > 2 ? *GetSidSubAuthority(pSid, 2) : 0,
-                           nSubAuthorityCount > 3 ? *GetSidSubAuthority(pSid, 3) : 0,
-                           nSubAuthorityCount > 4 ? *GetSidSubAuthority(pSid, 4) : 0,
-                           nSubAuthorityCount > 5 ? *GetSidSubAuthority(pSid, 5) : 0,
-                           nSubAuthorityCount > 6 ? *GetSidSubAuthority(pSid, 6) : 0,
-                           nSubAuthorityCount > 7 ? *GetSidSubAuthority(pSid, 7) : 0,
-                           ppSid);
+  return AllocateAndInitializeSid(GetSidIdentifierAuthority(pSid),
+                                  nSubAuthorityCount,
+                                  nSubAuthorityCount > 0 ? *GetSidSubAuthority(pSid, 0) : 0,
+                                  nSubAuthorityCount > 1 ? *GetSidSubAuthority(pSid, 1) : 0,
+                                  nSubAuthorityCount > 2 ? *GetSidSubAuthority(pSid, 2) : 0,
+                                  nSubAuthorityCount > 3 ? *GetSidSubAuthority(pSid, 3) : 0,
+                                  nSubAuthorityCount > 4 ? *GetSidSubAuthority(pSid, 4) : 0,
+                                  nSubAuthorityCount > 5 ? *GetSidSubAuthority(pSid, 5) : 0,
+                                  nSubAuthorityCount > 6 ? *GetSidSubAuthority(pSid, 6) : 0,
+                                  nSubAuthorityCount > 7 ? *GetSidSubAuthority(pSid, 7) : 0,
+                                  ppSid);
 }
 }
 #endif

--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -233,6 +233,30 @@ struct HostInfo {
   }
 };
 
+#if defined(OS_WIN32)
+namespace {
+inline AllocateAndCopySid(const PSID pSid, PSID *ppSid) noexcept {
+  if (!IsValidSid(pSid)) {
+    CreateWellKnownSid(WinNullSid, nullptr, ppSid, nullptr);
+    return;
+  }
+
+  DWORD nSubAuthorityCount = *GetSidSubAuthorityCount(pSid);
+  AllocateAndInitializeSid(GetSidIdentifierAuthority(pSid),
+                           nSubAuthorityCount,
+                           nSubAuthorityCount > 0 ? *GetSidSubAuthority(pSid, 0) : 0,
+                           nSubAuthorityCount > 1 ? *GetSidSubAuthority(pSid, 1) : 0,
+                           nSubAuthorityCount > 2 ? *GetSidSubAuthority(pSid, 2) : 0,
+                           nSubAuthorityCount > 3 ? *GetSidSubAuthority(pSid, 3) : 0,
+                           nSubAuthorityCount > 4 ? *GetSidSubAuthority(pSid, 4) : 0,
+                           nSubAuthorityCount > 5 ? *GetSidSubAuthority(pSid, 5) : 0,
+                           nSubAuthorityCount > 6 ? *GetSidSubAuthority(pSid, 6) : 0,
+                           nSubAuthorityCount > 7 ? *GetSidSubAuthority(pSid, 7) : 0,
+                           ppSid);
+}
+}
+#endif
+
 //
 // Describe a process
 //
@@ -312,33 +336,8 @@ struct ProcessInfo {
 
     pid = rhs.pid;
     name = rhs.name;
-
-    nSubAuthorityCount = *GetSidSubAuthorityCount(rhs.realUid);
-    AllocateAndInitializeSid(GetSidIdentifierAuthority(rhs.realUid),
-                             nSubAuthorityCount,
-                             nSubAuthorityCount > 0 ? *GetSidSubAuthority(rhs.realUid, 0) : 0,
-                             nSubAuthorityCount > 1 ? *GetSidSubAuthority(rhs.realUid, 1) : 0,
-                             nSubAuthorityCount > 2 ? *GetSidSubAuthority(rhs.realUid, 2) : 0,
-                             nSubAuthorityCount > 3 ? *GetSidSubAuthority(rhs.realUid, 3) : 0,
-                             nSubAuthorityCount > 4 ? *GetSidSubAuthority(rhs.realUid, 4) : 0,
-                             nSubAuthorityCount > 5 ? *GetSidSubAuthority(rhs.realUid, 5) : 0,
-                             nSubAuthorityCount > 6 ? *GetSidSubAuthority(rhs.realUid, 6) : 0,
-                             nSubAuthorityCount > 7 ? *GetSidSubAuthority(rhs.realUid, 7) : 0,
-                             &realUid);
-
-    nSubAuthorityCount = *GetSidSubAuthorityCount(rhs.realGid);
-    AllocateAndInitializeSid(GetSidIdentifierAuthority(rhs.realGid),
-                             nSubAuthorityCount,
-                             nSubAuthorityCount > 0 ? *GetSidSubAuthority(rhs.realGid, 0) : 0,
-                             nSubAuthorityCount > 1 ? *GetSidSubAuthority(rhs.realGid, 1) : 0,
-                             nSubAuthorityCount > 2 ? *GetSidSubAuthority(rhs.realGid, 2) : 0,
-                             nSubAuthorityCount > 3 ? *GetSidSubAuthority(rhs.realGid, 3) : 0,
-                             nSubAuthorityCount > 4 ? *GetSidSubAuthority(rhs.realGid, 4) : 0,
-                             nSubAuthorityCount > 5 ? *GetSidSubAuthority(rhs.realGid, 5) : 0,
-                             nSubAuthorityCount > 6 ? *GetSidSubAuthority(rhs.realGid, 6) : 0,
-                             nSubAuthorityCount > 7 ? *GetSidSubAuthority(rhs.realGid, 7) : 0,
-                             &realGid);
-
+    AllocateAndCopySid(rhs.realUid, &realUid);
+    AllocateAndCopySid(rhs.realGid, &realGid);
     cpuType = rhs.cpuType;
     cpuSubType = rhs.cpuSubType;
     nativeCPUType = rhs.nativeCPUType;

--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -330,8 +330,6 @@ struct ProcessInfo {
 
 
   ProcessInfo &operator=(const ProcessInfo &rhs) {
-    BYTE nSubAuthorityCount;
-
     pid = rhs.pid;
     name = rhs.name;
     AllocateAndCopySid(rhs.realUid, &realUid);


### PR DESCRIPTION
Ensure that we have a valid SID when copying the SID.  This avoids an
invalid access of the SID.