### PR TITLE
CI: remove configurations that are covered in GHA from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,14 +65,6 @@ build_and_test_android: &build_and_test_android
 
 version: 2
 jobs:
-  Style:
-    <<: *docker_config
-    steps:
-      - checkout
-      - run:
-          name: Apply clang-format
-          command: find Sources Headers -type f -exec clang-format -i -style=file {} \;
-      - *check_dirty_step
   Registers:
     <<: *docker_config
     steps:
@@ -81,26 +73,12 @@ jobs:
           name: Generate register descriptors
           command: ./Support/Scripts/generate-register-descriptors.sh
       - *check_dirty_step
-  Linux-X86:
-    <<: *build_and_test_defaults
-  Linux-X86-platform:
-    <<: *build_and_test_defaults
-    environment:
-      TARGET: Linux-X86
-      PLATFORM: 1
   Linux-X86-Clang:
     <<: *build_and_test_defaults
   Linux-X86-Clang-platform:
     <<: *build_and_test_defaults
     environment:
       TARGET: Linux-X86-Clang
-      PLATFORM: 1
-  Linux-X86_64:
-    <<: *build_and_test_defaults
-  Linux-X86_64-platform:
-    <<: *build_and_test_defaults
-    environment:
-      TARGET: Linux-X86_64
       PLATFORM: 1
   Linux-X86_64-Clang:
     <<: *build_and_test_defaults
@@ -151,23 +129,14 @@ jobs:
     <<: *build_only_defaults
   Tizen-ARM:
     <<: *build_only_defaults
-  MinGW-X86:
-    <<: *build_only_defaults
-  MinGW-X86_64:
-    <<: *build_only_defaults
 
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - Style
       - Registers
-      - Linux-X86
-      - Linux-X86-platform
       - Linux-X86-Clang
       - Linux-X86-Clang-platform
-      - Linux-X86_64
-      - Linux-X86_64-platform
       - Linux-X86_64-Clang
       - Linux-X86_64-Clang-platform
       - Linux-X86_64-GDB
@@ -180,5 +149,3 @@ workflows:
       - Android-X86_64
       - Tizen-X86
       - Tizen-ARM
-      - MinGW-X86
-      - MinGW-X86_64


### PR DESCRIPTION
CircleCI is not actively being used for testing, and the migration to
GHA has allowed us to get coverage for many of the configurations.
Remove the cases that are already converted to get a better idea of what
is left.