### PR TITLE
CI: bump GHA Windows MSVC builder to VS2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         run: choco install winflexbison3
 
       - name: Configure
-        run: cmake -B ${{ github.workspace }}/build -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake -D CMAKE_BUILD_TYPE=Release -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -S ${{ github.workspace }}
+        run: cmake -B ${{ github.workspace }}/build -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake -D CMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A ${{ matrix.arch }} -S ${{ github.workspace }}
       - name: Build
         run: cmake --build ${{ github.workspace }}/build --config Release
 


### PR DESCRIPTION
GitHub has updated the builders to VS2022, update the generator to use the
correct generator name to match that.