### PR TITLE
JSObjects: remove partial implementation of method

### DIFF
--- a/Tools/JSObjects/Sources/libjson/qstring.c
+++ b/Tools/JSObjects/Sources/libjson/qstring.c
@@ -17,6 +17,7 @@
 static int
 read_u (char **tmp, const char **str)
 {
+#if 0
   uint32_t uchar = 0;
   unsigned int i;
 
@@ -41,6 +42,8 @@ read_u (char **tmp, const char **str)
   */
 
 
+  return -1;
+#endif
   return -1;
 }
 


### PR DESCRIPTION
This temporarily pre-processes away the implementation to avoid disabling a
warning when building with a newer compiler - `-Werror=unused-but-set-variable`.