### PR TITLE
RegsGen2: avoid spelling `ssize_t`

### DIFF
--- a/Tools/RegsGen2/Definitions.h
+++ b/Tools/RegsGen2/Definitions.h
@@ -17,8 +17,10 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <sys/types.h>
+#include <type_traits>
 #include <vector>
+
+#include <sys/types.h>
 
 struct Register {
   typedef std::shared_ptr<Register> shared_ptr;
@@ -31,17 +33,17 @@ struct Register {
   bool Private;
   bool NoGDBRegisterNumber;
 
-  ssize_t BitSize;
+  typename std::make_signed<size_t>::type BitSize;
   ::Format Format;
   ::LLDBVectorFormat LLDBVectorFormat;
   ::Encoding Encoding;
   ::GDBEncoding GDBEncoding;
   std::string GDBEncodingName;
 
-  ssize_t GDBRegisterNumber;
-  ssize_t EHFrameRegisterNumber;
-  ssize_t DWARFRegisterNumber;
-  ssize_t LLDBRegisterNumber;
+  typename std::make_signed<size_t>::type GDBRegisterNumber;
+  typename std::make_signed<size_t>::type EHFrameRegisterNumber;
+  typename std::make_signed<size_t>::type DWARFRegisterNumber;
+  typename std::make_signed<size_t>::type LLDBRegisterNumber;
 
   std::string Name;
   std::string CName;
@@ -51,7 +53,7 @@ struct Register {
 
   std::string GDBGroup;
 
-  ssize_t LLDBOffset;
+  typename std::make_signed<size_t>::type LLDBOffset;
 
   vector InvalidateRegisters;
   vector ContainerRegisters;
@@ -62,7 +64,7 @@ struct Register {
 
   std::string ParentSetName;
   std::string ParentRegisterName;
-  ssize_t ParentElement;
+  typename std::make_signed<size_t>::type ParentElement;
   shared_ptr ParentRegister;
 
   Register()
@@ -104,7 +106,7 @@ struct GDBVector {
   typedef std::map<std::string, shared_ptr> name_map;
 
   size_t BitSize;
-  ssize_t ElementSize;
+  typename std::make_signed<size_t>::type ElementSize;
 
   std::string Name;
   ::GDBEncoding Encoding;

--- a/Tools/RegsGen2/FlagSet.cpp
+++ b/Tools/RegsGen2/FlagSet.cpp
@@ -112,7 +112,7 @@ bool FlagSet::parse(std::string const &name, JSDictionary const *d) {
       return false;
     }
 
-    for (ssize_t n = 0; n < length->value(); n++) {
+    for (typename std::make_signed<size_t>::type n = 0; n < length->value(); n++) {
       if (bits[n + start->value()]) {
         fprintf(stderr, "error: flag '%s' in flag set '%s' is "
                         "overlapping with other flags\n",

--- a/Tools/RegsGen2/FlagSet.h
+++ b/Tools/RegsGen2/FlagSet.h
@@ -14,6 +14,8 @@
 #include "JSObjects/JSObjects.h"
 #include "Definitions.h"
 
+#include <type_traits>
+
 #include <sys/types.h>
 
 class FlagSet {
@@ -22,7 +24,7 @@ public:
   typedef std::map<std::string, shared_ptr> name_map;
 
 private:
-  ssize_t _size;
+  typename std::make_signed<size_t>::type _size;
   std::string _name;
   std::string _GDBName;
   Flag::vector _flags;

--- a/Tools/RegsGen2/RegisterSet.cpp
+++ b/Tools/RegsGen2/RegisterSet.cpp
@@ -11,6 +11,8 @@
 #include "RegisterSet.h"
 #include "Context.h"
 
+#include <type_traits>
+
 RegisterSet::RegisterSet() {}
 
 bool RegisterSet::parse(Context &ctx, std::string const &name,
@@ -318,7 +320,7 @@ bool RegisterSet::finalize(Context &ctx) {
       }
 
       // (d)
-      ssize_t bitoff = reg->BitSize * reg->ParentElement;
+      typename std::make_signed<size_t>::type bitoff = reg->BitSize * reg->ParentElement;
       if (bitoff + reg->BitSize > preg->BitSize) {
         fprintf(stderr, "error: register '%s' references element #%zd "
                         "of register '%s' in register set '%s', but given the "

--- a/Tools/RegsGen2/RegisterTemplate.cpp
+++ b/Tools/RegsGen2/RegisterTemplate.cpp
@@ -16,7 +16,8 @@ RegisterTemplate::Number::Number() : _base(-1), _next(0) {}
 void RegisterTemplate::Number::init(size_t base) { _base = base; }
 
 bool RegisterTemplate::Number::mark(size_t index) {
-  if (_base < 0 || static_cast<ssize_t>(index) < _base)
+  if (_base < 0 ||
+      static_cast<typename std::make_signed<size_t>::type>(index) < _base)
     return false;
 
   index -= _base;
@@ -31,7 +32,7 @@ bool RegisterTemplate::Number::mark(size_t index) {
   return true;
 }
 
-ssize_t RegisterTemplate::Number::next() {
+typename std::make_signed<size_t>::type RegisterTemplate::Number::next() {
   if (_base < 0)
     return -1;
 
@@ -44,7 +45,7 @@ ssize_t RegisterTemplate::Number::next() {
   }
 
   _used[_next] = true;
-  ssize_t ret = _base + _next;
+  typename std::make_signed<size_t>::type ret = _base + _next;
   _next++;
   return ret;
 }

--- a/Tools/RegsGen2/RegisterTemplate.h
+++ b/Tools/RegsGen2/RegisterTemplate.h
@@ -14,11 +14,13 @@
 #include "JSObjects/JSObjects.h"
 #include "Definitions.h"
 
+#include <type_traits>
+
 class RegisterTemplate {
 private:
   class Number {
   private:
-    ssize_t _base;
+    typename std::make_signed<size_t>::type _base;
     std::vector<bool> _used;
     size_t _next;
 
@@ -32,7 +34,7 @@ private:
     bool mark(size_t index);
 
   public:
-    ssize_t next();
+    typename std::make_signed<size_t>::type next();
   };
 
 private:

--- a/Tools/RegsGen2/main.cpp
+++ b/Tools/RegsGen2/main.cpp
@@ -402,7 +402,8 @@ static std::string BuildGDBEncodingArray(Register const *reg) {
   return ss.str();
 }
 
-static std::string NameOfRegister(ssize_t regno, std::string const &name,
+static std::string NameOfRegister(typename std::make_signed<size_t>::type regno,
+                                  std::string const &name,
                                   std::string const &prefix) {
   if (regno < 0)
     return "-1";
@@ -842,8 +843,10 @@ static void GenerateGDBFeatures(FILE *fp, Context const &ctx) {
 // This is an helper function to emit endian-neutral offset for
 // subsetted registers.
 //
-static std::string GetLLDBOffset(Register const *parent, ssize_t bitsize,
-                                 ssize_t offset) {
+static std::string
+GetLLDBOffset(Register const *parent,
+              typename std::make_signed<size_t>::type bitsize,
+              typename std::make_signed<size_t>::type offset) {
   std::ostringstream ss;
   if (parent != nullptr && !(bitsize < 0) && !(offset < 0)) {
     ss << parent->LLDBOffset << " + "


### PR DESCRIPTION
Replace occurrences of `ssize_t` with some template metaprogramming to create
the equivalent signed type of `size_t` as `ssize_t` is a GNU extension rather
than a standard type.  This is needed to ensure that RegsGen2 is portable.