### PR TITLE
Core: add trailing commas to enums (NFC)

### DIFF
--- a/Headers/DebugServer2/Core/CPUTypes.h
+++ b/Headers/DebugServer2/Core/CPUTypes.h
@@ -54,7 +54,7 @@ enum CPUType {
   kCPUTypeALPHA = 16,
   // skip 17
   kCPUTypePOWERPC = 18,
-  kCPUTypePOWERPC64 = (kCPUTypePOWERPC | kCPUArchABI64)
+  kCPUTypePOWERPC64 = (kCPUTypePOWERPC | kCPUArchABI64),
 };
 
 //
@@ -229,7 +229,7 @@ enum CPUSubType {
   //
 
   kCPUSubTypeARM64_ALL = 0,
-  kCPUSubTypeARM64_V8 = 1
+  kCPUSubTypeARM64_V8 = 1,
 };
 
 static inline bool CPUTypeIs64Bit(CPUType type) {


### PR DESCRIPTION
With C++11 and newer, it is permissible to have a trailing common on the
enumerator list.  Use this to make it easier to extend the definitions.