### PR TITLE
CI: adjust build workflows to upload results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,13 @@ jobs:
       - name: Build
         run: cmake --build ${{ github.workspace }}/build --config Release
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: windows-${{ matrix.processor }}-ds2
+          path: |
+            build/ds2.exe
+
+
   mingw:
     runs-on: windows-latest
 
@@ -57,6 +64,12 @@ jobs:
       - name: Build
         run: cmake --build $(cygpath -u '${{ github.workspace }}/build') --config Release
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mingw-${{ matrix.system }}-ds2
+          path: |
+            build/ds2
+
   macos:
     runs-on: macos-latest
 
@@ -68,6 +81,12 @@ jobs:
         run: cmake -B ${{ github.workspace }}/out -C ${{ github.workspace }}/cmake/caches/ClangWarnings.cmake -D CMAKE_BUILD_TYPE=Release -G Ninja -S ${{ github.workspace }}
       - name: Build
         run: cmake --build ${{ github.workspace }}/out --config Release
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: macOS-x86_64-ds2
+          path: |
+            build/ds2
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           name: windows-${{ matrix.processor }}-ds2
           path: |
-            build/ds2.exe
+            build/Release/ds2.exe
 
 
   mingw:
@@ -86,7 +86,7 @@ jobs:
         with:
           name: macOS-x86_64-ds2
           path: |
-            build/ds2
+            build/ds2.exe
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: windows-${{ matrix.processor }}-ds2
+          name: windows-${{ matrix.arch }}-ds2
           path: |
             build/Release/ds2.exe
 
@@ -68,7 +68,7 @@ jobs:
         with:
           name: mingw-${{ matrix.system }}-ds2
           path: |
-            build/ds2
+            build/Release/ds2.exe
 
   macos:
     runs-on: macos-latest
@@ -86,7 +86,7 @@ jobs:
         with:
           name: macOS-x86_64-ds2
           path: |
-            build/ds2.exe
+            build/ds2
 
   linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds the binaries for Windows, MinGW, and macOS to the results.  This
should make it easier to use the results.