### PR TITLE
RISCV: add skeleton infrastructure for RISCV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@
 # Output Directories
 /build/
 /html/
+
+# Generated Data
+/Definitions/RISCV32.json
+/Definitions/RISCV64.json
+/Definitions/RISCV128.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,9 @@ elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "X86" OR
 elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "X64" OR
       CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64|x86_64")
   set(DS2_ARCHITECTURE X86_64)
+elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "RISCV32|RISCV64|RISCV128" OR
+       CMAKE_SYSTEM_PROCESSOR MATCHES "riscv32|riscv64|riscv128")
+  set(DS2_ARCHITECTURE RISCV)
 else()
   message(SEND_ERROR "Unknown host architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
@@ -123,7 +126,14 @@ set_target_properties(RegsGen2::RegsGen2 PROPERTIES
   IMPORTED_LOCATION ${BINARY_DIR}/${RegsGen2_RELATIVE_PATH})
 add_dependencies(RegsGen2::RegsGen2 RegsGen2)
 
-foreach(ARCH ARM ARM64 X86 X86_64)
+# Generate different pointer size RISC-V definitions.
+# FIXME(compnerd) this assumes all targets are RISCVnnnG, which may not be true.
+foreach(WORDSIZE 32 64 128)
+  configure_file(${PROJECT_SOURCE_DIR}/Definitions/RISCVnnn.json
+    ${PROJECT_SOURCE_DIR}/Definitions/RISCV${WORDSIZE}.json @ONLY)
+endforeach()
+
+foreach(ARCH ARM ARM64 RISCV32 RISCV64 RISCV128 X86 X86_64)
   add_custom_command(OUTPUT
       ${CMAKE_CURRENT_BINARY_DIR}/Headers/DebugServer2/Architecture/${ARCH}/RegistersDescriptors.h
     COMMAND
@@ -221,6 +231,28 @@ elseif(DS2_ARCHITECTURE MATCHES "X86|X86_64")
       ${CMAKE_CURRENT_BINARY_DIR}/Sources/Architecture/X86_64/RegistersDescriptors.cpp
       PROPERTIES
         COMPILE_OPTIONS $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-unused-const-variable>)
+  endif()
+elseif(DS2_ARCHITECTURE STREQUAL RISCV)
+  target_sources(ds2 PRIVATE
+    Sources/Architecture/RISCV/SoftwareSingleStep.cpp
+    Sources/Core/RISCV/HardwareBreakpointManager.cpp
+    Sources/Core/RISCV/SoftwareBreakpointManager.cpp)
+
+  if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "RISCV32" OR
+       CMAKE_SYSTEM_PROCESSOR MATCHES "riscv32")
+    target_sources(ds2 PRIVATE
+      ${CMAKE_CURRENT_BINARY_DIR}/Headers/DebugServer2/Architecture/RISCV32/RegistersDescriptors.h
+      ${CMAKE_CURRENT_BINARY_DIR}/Sources/Architecture/RISCV32/RegistersDescriptors.cpp)
+  elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "RISCV64" OR
+       CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+    target_sources(ds2 PRIVATE
+      ${CMAKE_CURRENT_BINARY_DIR}/Headers/DebugServer2/Architecture/RISCV64/RegistersDescriptors.h
+      ${CMAKE_CURRENT_BINARY_DIR}/Sources/Architecture/RISCV64/RegistersDescriptors.cpp)
+  elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "RISCV128" OR
+       CMAKE_SYSTEM_PROCESSOR MATCHES "riscv128")
+    target_sources(ds2 PRIVATE
+      ${CMAKE_CURRENT_BINARY_DIR}/Headers/DebugServer2/Architecture/RISCV128/RegistersDescriptors.h
+      ${CMAKE_CURRENT_BINARY_DIR}/Sources/Architecture/RISCV128/RegistersDescriptors.cpp)
   endif()
 endif()
 

--- a/Definitions/RISCVnnn.json
+++ b/Definitions/RISCVnnn.json
@@ -1,0 +1,353 @@
+//
+// Copyright (c) 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+// All Rights Reserved.
+//
+
+{
+    "namespace": "RISCV@WORDSIZE@",
+    "register-sets": {
+        "gpr": {
+            "*": {
+                "bit-size": @WORDSIZE@,
+                "encoding": "int",
+                "format": "hex",
+
+                "base-gdb-reg-number": 0,
+                "base-ehframe-reg-number": 0,
+                "base-dwarf-reg-number": 0
+            },
+
+            "x0": {
+                "alternate-name": "zero",
+                "generic-name": "zero"
+            },
+            "x1": {
+                "alternate-name": "ra",
+                "gdb-encoding": "code-pointer",
+                "generic-name": "ra"
+            },
+            "x2": {
+                "alternate-name": "sp",
+                "gdb-encoding": "data-pointer",
+                "generic-name": "sp"
+            },
+            "x3": {
+                "alternate-name": "gp",
+                "gdb-encoding": "data-pointer",
+                "generic-name": "gp"
+            },
+            "x4": {
+                "alternate-name": "tp",
+                "gdb-encoding": "data-pointer",
+                "generic-name": "tp"
+            },
+            "x5": {
+                "alternate-name": "t0",
+                "generic-name": "t0"
+            },
+            "x6": {
+                "alternate-name": "t1",
+                "generic-name": "t1"
+            },
+            "x7": {
+                "alternate-name": "t2",
+                "generic-name": "t2"
+            },
+            "x8": {
+                "alternate-name": "fp",
+                "gdb-encoding": "data-pointer",
+                "generic-name": "s0"
+            },
+            "x9": {
+                "alternate-name": "s1",
+                "generic-name": "s1"
+            },
+            "x10": {
+                "alternate-name": "a0",
+                "generic-name": "a0"
+            },
+            "x11": {
+                "alternate-name": "a1",
+                "generic-name": "a1"
+            },
+            "x12": {
+                "alternate-name": "a2",
+                "generic-name": "a2"
+            },
+            "x13": {
+                "alternate-name": "a3",
+                "generic-name": "a3"
+            },
+            "x14": {
+                "alternate-name": "a4",
+                "generic-name": "a4"
+            },
+            "x15": {
+                "alternate-name": "a5",
+                "generic-name": "a5"
+            },
+            "x16": {
+                "alternate-name": "a6",
+                "generic-name": "a6"
+            },
+            "x17": {
+                "alternate-name": "a7",
+                "generic-name": "a7"
+            },
+            "x18": {
+                "alternate-name": "s2",
+                "generic-name": "s2"
+            },
+            "x19": {
+                "alternate-name": "s3",
+                "generic-name": "s3"
+            },
+            "x20": {
+                "alternate-name": "s4",
+                "generic-name": "s4"
+            },
+            "x21": {
+                "alternate-name": "s5",
+                "generic-name": "s5"
+            },
+            "x22": {
+                "alternate-name": "s6",
+                "generic-name": "s6"
+            },
+            "x23": {
+                "alternate-name": "s7",
+                "generic-name": "s7"
+            },
+            "x24": {
+                "alternate-name": "s8",
+                "generic-name": "s8"
+            },
+            "x25": {
+                "alternate-name": "s9",
+                "generic-name": "s9"
+            },
+            "x26": {
+                "alternate-name": "s10",
+                "generic-name": "s10"
+            },
+            "x27": {
+                "alternate-name": "s11",
+                "generic-name": "s11"
+            },
+            "x28": {
+                "alternate-name": "t3",
+                "generic-name": "t3"
+            },
+            "x29": {
+                "alternate-name": "t4",
+                "generic-name": "t4"
+            },
+            "x30": {
+                "alternate-name": "t5",
+                "generic-name": "t5"
+            },
+            "x31": {
+                "alternate-name": "t6",
+                "generic-name": "t6"
+            },
+            "pc": {
+                "gdb-encoding": "code-pointer",
+                "generic-name": "pc"
+            }
+        },
+
+        "fpr": {
+            "*": {
+                "bit-size": 64,
+                "encoding": "ieee-double",
+                "format": "float",
+
+                "base-gdb-reg-number": 33
+            },
+
+            "f0": {
+                "alternate-name": "ft0",
+                "generic-name": "f0"
+            },
+            "f1": {
+                "alternate-name": "ft1",
+                "generic-name": "f1"
+            },
+            "f2": {
+                "alternate-name": "ft2",
+                "generic-name": "f2"
+            },
+            "f3": {
+                "alternate-name": "ft3",
+                "generic-name": "f3"
+            },
+            "f4": {
+                "alternate-name": "ft4",
+                "generic-name": "f4"
+            },
+            "f5": {
+                "alternate-name": "ft5",
+                "generic-name": "f5"
+            },
+            "f6": {
+                "alternate-name": "ft6",
+                "generic-name": "f6"
+            },
+            "f7": {
+                "alternate-name": "ft7",
+                "generic-name": "f7"
+            },
+            "f8": {
+                "alternate-name": "fs0",
+                "generic-name": "f8"
+            },
+            "f9": {
+                "alternate-name": "fs1",
+                "generic-name": "f9"
+            },
+            "f10": {
+                "alternate-name": "fa0",
+                "generic-name": "f10"
+            },
+            "f11": {
+                "alternate-name": "fa1",
+                "generic-name": "f11"
+            },
+            "f12": {
+                "alternate-name": "fa2",
+                "generic-name": "f12"
+            },
+            "f13": {
+                "alternate-name": "fa3",
+                "generic-name": "f13"
+            },
+            "f14": {
+                "alternate-name": "fa4",
+                "generic-name": "f14"
+            },
+            "f15": {
+                "alternate-name": "fa5",
+                "generic-name": "f15"
+            },
+            "f16": {
+                "alternate-name": "fa6",
+                "generic-name": "f16"
+            },
+            "f17": {
+                "alternate-name": "fa7",
+                "generic-name": "f17"
+            },
+            "f18": {
+                "alternate-name": "fs2",
+                "generic-name": "f18"
+            },
+            "f19": {
+                "alternate-name": "fs3",
+                "generic-name": "f19"
+            },
+            "f20": {
+                "alternate-name": "fs4",
+                "generic-name": "f20"
+            },
+            "f21": {
+                "alternate-name": "fs5",
+                "generic-name": "f21"
+            },
+            "f22": {
+                "alternate-name": "fs6",
+                "generic-name": "f22"
+            },
+            "f23": {
+                "alternate-name": "fs7",
+                "generic-name": "f23"
+            },
+            "f24": {
+                "alternate-name": "fs8",
+                "generic-name": "f24"
+            },
+            "f25": {
+                "alternate-name": "fs9",
+                "generic-name": "f25"
+            },
+            "f26": {
+                "alternate-name": "fs10",
+                "generic-name": "f26"
+            },
+            "f27": {
+                "alternate-name": "fs11",
+                "generic-name": "f27"
+            },
+            "f28": {
+                "alternate-name": "ft8",
+                "generic-name": "f28"
+            },
+            "f29": {
+                "alternate-name": "ft9",
+                "generic-name": "f29"
+            },
+            "f30": {
+                "alternate-name": "ft10",
+                "generic-name": "f30"
+            },
+            "f31": {
+                "alternate-name": "ft11",
+                "generic-name": "f31"
+            },
+
+            "fflags": {
+                "alternate-name": "csr1",
+                "bit-size": 32,
+                "encoding": "int",
+                "format": "hex",
+                "gdb-encoding": "int",
+                "gdb-reg-number": 66
+            },
+            "frm": {
+                "alternate-name": "csr2",
+                "bit-size": 32,
+                "encoding": "int",
+                "format": "hex",
+                "gdb-encoding": "int",
+                "gdb-reg-number": 67
+            },
+            "fcsr": {
+                "alternate-name": "csr3",
+                "bit-size": 32,
+                "encoding": "int",
+                "format": "hex",
+                "gdb-encoding": "int",
+                "gdb-reg-number": 68
+            }
+        }
+    },
+
+    "gdb-defs": {
+        "architecture": "riscv",
+        "features": [
+            {
+                "filename": "riscv/@WORDSIZE@bit-cpu.xml",
+                "identifier": "org.gnu.gdb.riscv.cpu",
+                "contents": [
+                    "register-sets:gpr"
+                ]
+            },
+            {
+                "filename": "riscv/64bit-fpu.xml",
+                "identifier": "org.gnu.gdb.riscv.fpu",
+                "contents": [
+                    "register-sets:fpr"
+                ]
+            }
+        ]
+    },
+    "lldb-defs": [
+        {
+            "description": "General Purpose Registers",
+            "sets": ["gpr"]
+        },
+        {
+            "description": "Floating Point Registers",
+            "sets": ["fpr"]
+        }
+    ]
+}

--- a/Headers/DebugServer2/Architecture/CPUState.h
+++ b/Headers/DebugServer2/Architecture/CPUState.h
@@ -24,6 +24,8 @@
 #elif defined(ARCH_X86_64)
 #include "DebugServer2/Architecture/X86/CPUState.h"
 #include "DebugServer2/Architecture/X86_64/CPUState.h"
+#elif defined(ARCH_RISCV)
+#include "DebugServer2/Architecture/RISCV/CPUState.h"
 #else
 #error "Architecture not supported."
 #endif
@@ -40,6 +42,8 @@ using ARM64::CPUState;
 using X86::CPUState;
 #elif defined(ARCH_X86_64)
 using X86_64::CPUState;
+#elif defined(ARCH_RISCV)
+using RISCV::CPUState;
 #else
 #error "Architecture not supported."
 #endif

--- a/Headers/DebugServer2/Architecture/RISCV/CPUState.h
+++ b/Headers/DebugServer2/Architecture/RISCV/CPUState.h
@@ -1,0 +1,177 @@
+// Copyright 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+
+#pragma once
+
+#if !defined(CPUSTATE_H_INTERNAL)
+#error "You shall not include this file directly."
+#endif
+
+#if __riscv_xlen == 32
+#include "DebugServer2/Architecture/RISCV32/RegistersDescriptors.h"
+#elif __riscv_xlen == 64
+#include "DebugServer2/Architecture/RISCV64/RegistersDescriptors.h"
+#elif __riscv_xlen == 128
+#include "DebugServer2/Architecture/RISCV128/RegistersDescriptors.h"
+#endif
+
+#include <algorithm>
+
+namespace ds2 {
+namespace Architecture {
+namespace RISCV {
+
+#pragma pack(push)
+
+struct CPUState {
+  union {
+    uintptr_t regs[32];
+    struct {
+      // NOTE: pc takes the x0 slot to match `struct user_reg_state`.  x0 is
+      // hardwired to zero, so the value can always be materialized.
+      uintptr_t pc, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14,
+          x15, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28,
+          x29, x30, x31;
+    };
+  } gp = {0};
+
+  // TODO(compnerd) support quad precision
+  struct {
+    union {
+      uint32_t sng[32];
+      uint64_t dbl[32];
+    };
+    uint32_t fcsr;
+  } fp = {0};
+
+public:
+  //
+  // Accessors
+  //
+
+  inline uintptr_t pc() const { return gp.pc; }
+  inline void setPC(uintptr_t pc) { gp.pc = pc; }
+
+  inline uintptr_t retval() const { return gp.x1; }
+
+public:
+  inline void getGPState(GPRegisterValueVector &regs) const {
+    regs.clear();
+    regs.emplace_back(GPRegisterValue{sizeof(uintptr_t), 0x0});
+    std::transform(std::next(std::begin(gp.regs)), std::end(gp.regs),
+                   std::back_inserter(regs),
+                   [](uintptr_t reg) -> GPRegisterValue {
+                     return GPRegisterValue{sizeof(reg), reg};
+                   });
+    regs.emplace_back(GPRegisterValue{sizeof(uintptr_t), gp.pc});
+  }
+
+  inline void setGPState(std::vector<uintptr_t> const &regs) {
+    for (size_t reg = 1, nregs = std::min(std::size(regs), std::size(gp.regs));
+         reg < nregs; ++reg)
+      gp.regs[reg % (std::size(gp.regs) - 1)] = regs[reg];
+  }
+
+public:
+  inline void getStopGPState(GPRegisterStopMap &regs, bool forLLDB) const {
+#if __riscv_xlen == 32
+    using namespace ds2::Architecture::RISCV32;
+#elif __riscv_xlen == 64
+    using namespace ds2::Architecture::RISCV64;
+#elif __riscv_xlen == 128
+    using namespace ds2::Architecture::RISCV128;
+#endif
+
+    if (forLLDB) {
+      regs[reg_lldb_x0] = GPRegisterValue{sizeof(uintptr_t), 0};
+      for (size_t reg = 1, nregs = std::size(gp.regs); reg < nregs; ++reg)
+        regs[reg_lldb_x0 + reg] =
+            GPRegisterValue{sizeof(uintptr_t), gp.regs[reg]};
+        regs[reg_lldb_pc] = GPRegisterValue{sizeof(uintptr_t), gp.pc};
+    } else {
+      regs[reg_gdb_x0] = GPRegisterValue{sizeof(uintptr_t), 0};
+      for (size_t reg = 1, nregs = std::size(gp.regs); reg < nregs; ++reg)
+        regs[reg_gdb_x0 + reg] =
+            GPRegisterValue{sizeof(uintptr_t), gp.regs[reg]};
+        regs[reg_gdb_pc] = GPRegisterValue{sizeof(uintptr_t), gp.pc};
+    }
+  }
+
+public:
+  inline bool getLLDBRegisterPtr(int regno, void **ptr, size_t *length) const {
+#if __riscv_xlen == 32
+    using namespace ds2::Architecture::RISCV32;
+#elif __riscv_xlen == 64
+    using namespace ds2::Architecture::RISCV64;
+#elif __riscv_xlen == 128
+    using namespace ds2::Architecture::RISCV128;
+#endif
+
+    if (regno >= reg_lldb_x1 && regno <= reg_lldb_x31) {
+      *ptr = const_cast<uintptr_t *>(&gp.regs[regno - reg_lldb_x1]);
+      *length = sizeof(gp.regs[0]);
+    } else if (regno == reg_lldb_pc) {
+      *ptr = const_cast<uintptr_t *>(&gp.pc);
+      *length = sizeof(gp.pc);
+    } else if (regno >= reg_lldb_f0 && regno <= reg_lldb_f31) {
+#if __riscv_flen == 32
+      *ptr = const_cast<uint32_t *>(&fp.sng[regno - reg_lldb_f0]);
+      *length = sizeof(fp.sng[0]);
+#elif __riscv_flen == 64
+      *ptr = const_cast<uint64_t *>(&fp.dbl[regno - reg_lldb_f0]);
+      *length = sizeof(fp.dbl[0]);
+#elif __riscv_flen == 128
+#error "quad precision floating point support unimplemented"
+#else
+      return false;
+#endif
+    } else if (regno == reg_lldb_fcsr) {
+      *ptr = const_cast<uint32_t *>(&fp.fcsr);
+      *length = sizeof(fp.fcsr);
+    } else {
+      return false;
+    }
+    return true;
+  }
+
+  inline bool getGDBRegisterPtr(int regno, void **ptr, size_t *length) const {
+#if __riscv_xlen == 32
+    using namespace ds2::Architecture::RISCV32;
+#elif __riscv_xlen == 64
+    using namespace ds2::Architecture::RISCV64;
+#elif __riscv_xlen == 128
+    using namespace ds2::Architecture::RISCV128;
+#endif
+
+    if (regno >= reg_gdb_x1 && regno <= reg_gdb_x31) {
+      *ptr = const_cast<uintptr_t *>(&gp.regs[regno - reg_gdb_x1]);
+      *length = sizeof(gp.regs[0]);
+    } else if (regno == reg_gdb_pc) {
+      *ptr = const_cast<uintptr_t *>(&gp.pc);
+      *length = sizeof(gp.pc);
+    } else if (regno >= reg_gdb_f0 && regno <= reg_gdb_f31) {
+#if __riscv_flen == 32
+      *ptr = const_cast<uint32_t *>(&fp.sng[regno - reg_gdb_f0]);
+      *length = sizeof(fp.sng[0]);
+#elif __riscv_flen == 64
+      *ptr = const_cast<uint64_t *>(&fp.dbl[regno - reg_gdb_f0]);
+      *length = sizeof(fp.dbl[0]);
+#elif __riscv_flen == 128
+#error "quad precision floating point support unimplemented"
+#else
+      return false;
+#endif
+    } else if (regno == reg_gdb_fcsr) {
+      *ptr = const_cast<uint32_t *>(&fp.fcsr);
+      *length = sizeof(fp.fcsr);
+    } else {
+      return false;
+    }
+    return true;
+  }
+};
+
+#pragma pack(pop)
+
+} // namespace RISCV
+} // namespace Architecture
+} // namespace ds2

--- a/Headers/DebugServer2/Architecture/RISCV/SoftwareSingleStep.h
+++ b/Headers/DebugServer2/Architecture/RISCV/SoftwareSingleStep.h
@@ -1,0 +1,20 @@
+// Copyright 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+
+#pragma once
+
+#include "DebugServer2/Architecture/CPUState.h"
+#include "DebugServer2/Core/BreakpointManager.h"
+#include "DebugServer2/Target/Process.h"
+
+namespace ds2 {
+namespace Architecture {
+namespace RISCV {
+
+ErrorCode PrepareSoftwareSingleStep(Target::Process *process,
+                                    BreakpointManager *manager,
+                                    CPUState const &state,
+                                    Address const &address);
+
+} // namespace RISCV
+} // namespace Architecture
+} // namespace ds2

--- a/Headers/DebugServer2/Base.h
+++ b/Headers/DebugServer2/Base.h
@@ -76,6 +76,15 @@ typedef SSIZE_T ssize_t;
 #elif defined(__x86_64__) || defined(_M_AMD64)
 #define ARCH_X86_64
 #define BITSIZE_64
+#elif defined(__riscv)
+#define ARCH_RISCV
+#if __riscv_xlen == 32
+#define BITSIZE_32
+#elif __riscv_xlen == 64
+#define BITSIZE_64
+#elif __riscv_xlen == 128
+#define BITSIZE_128
+#endif
 #else
 #error "Architecture not supported."
 #endif

--- a/Headers/DebugServer2/Core/CPUTypes.h
+++ b/Headers/DebugServer2/Core/CPUTypes.h
@@ -55,6 +55,13 @@ enum CPUType {
   // skip 17
   kCPUTypePOWERPC = 18,
   kCPUTypePOWERPC64 = (kCPUTypePOWERPC | kCPUArchABI64),
+  // skip 19
+  // TODO(compnerd) these do not map consistently with the remainder of the CPU
+  // codes which mirror the Darwin constants.  These values here correspond to
+  // the PE/COFF specification.
+  kCPUTypeRISCV32 = 0x5032,
+  kCPUTypeRISCV64 = 0x5064,
+  kCPUTypeRISCV128 = 0x5128,
 };
 
 //
@@ -230,10 +237,29 @@ enum CPUSubType {
 
   kCPUSubTypeARM64_ALL = 0,
   kCPUSubTypeARM64_V8 = 1,
+
+  //
+  // kCPUTypeRISCV32
+  //
+
+  kCPUSubTypeRISCV32_ALL = 0,
+
+  //
+  // kCPUTypeRISCV64
+  //
+
+  kCPUSubTypeRISCV64_ALL = 0,
+
+  //
+  // kCPUTypeRISCV128
+  //
+
+  kCPSubTypeRISCV128_ALL = 0,
 };
 
 static inline bool CPUTypeIs64Bit(CPUType type) {
-  return ((type & kCPUArchABI64) != 0 || type == kCPUTypeALPHA);
+  return type & kCPUArchABI64 || type == kCPUTypeALPHA ||
+         type == kCPUTypeRISCV64;
 }
 
 char const *GetCPUTypeName(CPUType type);

--- a/Headers/DebugServer2/Utils/Log.h
+++ b/Headers/DebugServer2/Utils/Log.h
@@ -46,6 +46,8 @@ void Log(int level, char const *classname, char const *funcname,
 #define PRI_PTR "#010" PRIxPTR
 #elif defined(BITSIZE_64)
 #define PRI_PTR "#018" PRIxPTR
+#elif defined(BITSIZE_128)
+#define PRI_PTR "#034" PRIxPTR
 #endif
 
 #define PRI_PTR_CAST(VAL) ((uintptr_t)(VAL))

--- a/Sources/Architecture/RISCV/SoftwareSingleStep.cpp
+++ b/Sources/Architecture/RISCV/SoftwareSingleStep.cpp
@@ -1,0 +1,171 @@
+// Copyright 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+
+#include "DebugServer2/Architecture/RISCV/SoftwareSingleStep.h"
+#include "DebugServer2/Utils/Log.h"
+
+namespace ds2 {
+namespace Architecture {
+namespace RISCV {
+
+namespace {
+template <size_t Width>
+uintptr_t sext(uintptr_t value) {
+  return ((value & (1 << Width)) ? ~((value & (1 << Width)) - 1) : 0) |
+         (value & ((1 << Width + 1) - 1));
+}
+}
+
+ErrorCode PrepareSoftwareSingleStep(Target::Process *process,
+                                    BreakpointManager *manager,
+                                    CPUState const &state,
+                                    Address const &address) {
+  uintptr_t location = address.valid() ? address.value() : state.pc();
+
+  uint16_t instruction;
+  CHK(process->readMemory(location, &instruction, sizeof(instruction)));
+
+  uintptr_t destination;
+  if ((instruction & 0x3) == 0x3) {                         // RVI
+    uint32_t instruction;
+    CHK(process->readMemory(location, &instruction, sizeof(instruction)));
+
+    switch (instruction & 0x0000007f) {
+    default:
+      destination = location + 4;
+      break;
+    case 0x00000063: {                                      // BRANCH
+      uint8_t rs1 = ((instruction & 0x000f8000) >> 15);
+      uint8_t rs2 = ((instruction & 0x01f00000) >> 20);
+      uintptr_t immediate = (((instruction & 0x00000f00) >>  8) <<  1)
+                          | (((instruction & 0x7e000000) >> 25) <<  5)
+                          | (((instruction & 0x00000080) >>  7) << 11)
+                          | (((instruction & 0x80000000) >> 31) << 12);
+      uintptr_t lhs = rs1 ? state.gp.regs[rs1] : 0;
+      uintptr_t rhs = rs2 ? state.gp.regs[rs2] : 0;
+      switch ((instruction & 0x00007000) >> 12) {
+      case 0: // EQ
+        destination = location + (lhs == rhs ? sext<12>(immediate) : 4);
+        break;
+      case 1: // NE
+        destination = location + (lhs == rhs ? 4 : sext<12>(immediate));
+        break;
+      case 2:
+        DS2LOG(Debug, "unknown branch condition funct3=2");
+        DS2BUG("unknown branch condition 2");
+      case 3:
+        DS2LOG(Debug, "unknown branch condition funct3=3");
+        DS2BUG("unknown branch condition 3");
+      case 4: // LT
+        destination =
+            location + (static_cast<intptr_t>(lhs) < static_cast<intptr_t>(rhs)
+                            ? sext<12>(immediate)
+                            : 4);
+        break;
+      case 5: // GE
+        destination =
+            location + (static_cast<intptr_t>(lhs) >= static_cast<intptr_t>(rhs)
+                            ? sext<12>(immediate)
+                            : 4);
+        break;
+      case 6: // LTU
+        destination = location + (lhs < rhs ? sext<12>(immediate) : 4);
+        break;
+      case 7: // GTU
+        destination = location + (lhs >= rhs ? sext<12>(immediate) : 4);
+        break;
+      }
+      break;
+    }
+    case 0x00000067: {
+      switch (instruction & 0x00007000) {
+      default:
+        destination = location + 4;
+        break;
+      case 0: {                                             // JALR
+        uint8_t rs = ((instruction & 0x000f8000) >> 15);
+        uint8_t rd = ((instruction & 0x00000f80) >>  7);
+        uintptr_t immediate = (instruction & 0xfff00000) >> 20;
+        (void)rd;
+        uintptr_t base = rs ? state.gp.regs[rs] : 0;
+        destination = base + sext<11>(immediate);
+        break;
+      }
+      }
+      break;
+    }
+    case 0x0000006f: {                                      // JAL
+      uintptr_t immediate = (((instruction & 0x7fe00000) >> 21) <<  1)
+                          | (((instruction & 0x00100000) >> 20) << 11)
+                          | (((instruction & 0x000ff000) >> 12) << 12)
+                          | (((instruction & 0x80000000) >> 31) << 20);
+      destination = location + sext<20>(immediate);
+      break;
+    }
+    }
+  } else {                                                  // RVC
+    destination = location + 2;
+    switch ((instruction & 0x3) >>  0) {
+    default: break;
+    case 0x01:
+      switch ((instruction & 0xe000) >> 13) {
+      default: break;
+#if __riscv_len == 32
+      case 1:                                               // C.JAL
+        [[fallthrough]];
+#endif
+      case 5: {                                             // C.J
+        uintptr_t immediate = (((instruction & 0x0038) >>  3) <<  1)
+                            | (((instruction & 0x0800) >> 11) <<  4)
+                            | (((instruction & 0x0004) >>  2) <<  5)
+                            | (((instruction & 0x0080) >>  7) <<  6)
+                            | (((instruction & 0x0040) >>  6) <<  7)
+                            | (((instruction & 0x0600) >>  9) <<  8)
+                            | (((instruction & 0x0100) >>  8) << 10)
+                            | (((instruction & 0x1000) >> 12) << 11);
+        destination = location + sext<11>(immediate);
+        break;
+      }
+      case 6:                                               // C.BEQZ
+        [[fallthrough]];
+      case 7: {                                             // C.BNEZ
+        uintptr_t immediate = (((instruction & 0x0018) >>  3) << 1)
+                            | (((instruction & 0x0c00) >> 10) << 3)
+                            | (((instruction & 0x0004) >>  2) << 5)
+                            | (((instruction & 0x0060) >>  5) << 6)
+                            | (((instruction & 0x1000) >> 12) << 8);
+        uint8_t rs = (instruction & 0x0380) >> 7;
+        bool eq = ((instruction & 0xe000) >> 13) == 6;
+        destination = location +
+                      ((eq ? state.gp.regs[rs + 8] == 0 : state.gp.regs[rs + 8])
+                           ? sext<8>(immediate)
+                           : 2);
+        break;
+      }
+      }
+    case 0x02:
+      switch ((instruction & 0xf000) >> 12) {
+      default: break;
+      case 8:                                               // C.JR
+        [[fallthrough]];
+      case 9: {                                             // C.JALR
+        if ((instruction & 0x007c) >> 2)
+          break;
+
+        uint8_t rs1 = ((instruction & 0x0f80) >> 7);
+        destination = state.gp.regs[rs1];
+        break;
+      }
+      }
+    }
+  }
+
+  CHK(process->readMemory(destination, &instruction, sizeof(instruction)));
+  CHK(manager->add(destination, BreakpointManager::Lifetime::TemporaryOneShot,
+                   (instruction & 0x0003) == 0x0003 ? 4 : 2,
+                   BreakpointManager::kModeExec));
+  return kSuccess;
+}
+
+} // namespace RISCV
+} // namespace Architecture
+} // namespace ds2

--- a/Sources/Core/CPUTypes.cpp
+++ b/Sources/Core/CPUTypes.cpp
@@ -54,6 +54,12 @@ char const *GetCPUTypeName(CPUType type) {
     return "POWERPC";
   case kCPUTypePOWERPC64:
     return "POWERPC64";
+  case kCPUTypeRISCV32:
+    return "RISCV32";
+  case kCPUTypeRISCV64:
+    return "RISCV64";
+  case kCPUTypeRISCV128:
+    return "RISCV128";
   default:
     break;
   }
@@ -112,6 +118,12 @@ char const *GetArchName(CPUType type, CPUSubType subtype) {
     return "powerpc";
   case kCPUTypePOWERPC64:
     return "powerpc64";
+  case kCPUTypeRISCV32:
+    return "riscv32";
+  case kCPUTypeRISCV64:
+    return "riscv64";
+  case kCPUTypeRISCV128:
+    return "riscv128";
   default:
     break;
   }
@@ -156,6 +168,12 @@ char const *GetArchName(CPUType type, CPUSubType subtype, Endian endian) {
       return "mips64el";
     else
       return "mips64eb";
+  case kCPUTypeRISCV32:
+    return endian == kEndianLittle ? "riscv32" : "riscv32be";
+  case kCPUTypeRISCV64:
+    return endian == kEndianLittle ? "riscv64" : "riscv64be";
+  case kCPUTypeRISCV128:
+    return endian == kEndianLittle ? "riscv128" : "riscv128be";
   default:
     break;
   }

--- a/Sources/Core/RISCV/HardwareBreakpointManager.cpp
+++ b/Sources/Core/RISCV/HardwareBreakpointManager.cpp
@@ -1,0 +1,38 @@
+// Copyright 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+
+#include "DebugServer2/Core/HardwareBreakpointManager.h"
+#include "DebugServer2/Target/Process.h"
+#include "DebugServer2/Target/Thread.h"
+
+#define super ds2::BreakpointManager
+
+namespace ds2 {
+
+int HardwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
+  return -1;
+};
+
+ErrorCode HardwareBreakpointManager::enableLocation(Site const &site, int index,
+                                                    Target::Thread *thread) {
+  return kErrorUnsupported;
+}
+
+ErrorCode HardwareBreakpointManager::disableLocation(int index,
+                                                     Target::Thread *thread) {
+  return kErrorUnsupported;
+}
+
+size_t HardwareBreakpointManager::maxWatchpoints() {
+  return _process->getMaxWatchpoints();
+}
+
+ErrorCode HardwareBreakpointManager::isValid(Address const &address,
+                                             size_t size, Mode mode) const {
+  return kErrorUnsupported;
+}
+
+size_t HardwareBreakpointManager::chooseBreakpointSize(Address const &) const {
+  return -1;
+}
+
+} // namespace ds2

--- a/Sources/Core/RISCV/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/RISCV/SoftwareBreakpointManager.cpp
@@ -1,0 +1,62 @@
+// Copyright 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+
+#include "DebugServer2/Core/SoftwareBreakpointManager.h"
+#include "DebugServer2/Target/Process.h"
+#include "DebugServer2/Target/Thread.h"
+
+#define super ds2::BreakpointManager
+
+namespace ds2 {
+
+int SoftwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
+  ds2::Architecture::CPUState state;
+  thread->readCPUState(state);
+  return super::hit(state.pc(), site) ? 0 : -1;
+}
+
+void SoftwareBreakpointManager::getOpcode(uint32_t type,
+                                          ByteVector &opcode) const {
+  opcode.clear();
+
+  switch (type) {
+  case 2: // c.ebreak
+    opcode.push_back('\x02');
+    opcode.push_back('\x90');
+    break;
+  case 4: // ebreak
+    opcode.push_back('\x73');
+    opcode.push_back('\x00');
+    opcode.push_back('\x10');
+    opcode.push_back('\x00');
+    break;
+  default:
+    DS2LOG(Error, "unsupported breakpoint width '%u'", type);
+    DS2BUG("unsupported breakpoint width");
+    break;
+  }
+}
+
+ErrorCode SoftwareBreakpointManager::isValid(Address const &address,
+                                             size_t size, Mode mode) const {
+  DS2ASSERT(mode == kModeExec);
+  if (size == 0 || size == 2 || size == 4)
+    return super::isValid(address, size, mode);
+  DS2LOG(Debug, "received unsupported breakpoint size '%zu'", size);
+  return kErrorInvalidArgument;
+}
+
+size_t
+SoftwareBreakpointManager::chooseBreakpointSize(Address const &address) const {
+  uint16_t instruction;
+  CHK(_process->readMemory(address.value(), &instruction, sizeof(instruction)));
+
+  // TODO(compnerd) move this into ds2::Architecture::RISCV::GetInstructionSize
+  if ((instruction & 0x03) != 0x03) // RVC
+    return 2;
+  if ((instruction & 0x1f) != 0x1f) // RVI
+    return 4;
+  // TODO(compnerd) handle 48-bit, 64-bit, and larger instructions
+  return 2;
+}
+
+} // namespace ds2

--- a/Sources/Host/Common/Platform.cpp
+++ b/Sources/Host/Common/Platform.cpp
@@ -19,6 +19,14 @@ ds2::CPUType Platform::GetCPUType() {
   return (sizeof(void *) == 8) ? kCPUTypeARM64 : kCPUTypeARM;
 #elif defined(ARCH_X86) || defined(ARCH_X86_64)
   return (sizeof(void *) == 8) ? kCPUTypeX86_64 : kCPUTypeI386;
+#elif defined(ARCH_RISCV)
+#if __riscv_xlen == 32
+  return kCPUTypeRISCV32;
+#elif __riscv_xlen == 64
+  return kCPUTypeRISCV64;
+#elif __riscv_xlen == 128
+  return kCPUTypeRISCV128;
+#endif
 #else
 #error "Architecture not supported."
 #endif

--- a/Sources/Host/Linux/RISCV/PTraceRISCV.cpp
+++ b/Sources/Host/Linux/RISCV/PTraceRISCV.cpp
@@ -1,0 +1,76 @@
+// Copyright 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+
+#include "DebugServer2/Host/Linux/PTrace.h"
+#include "DebugServer2/Core/HardwareBreakpointManager.h"
+#include "DebugServer2/Host/Linux/ExtraWrappers.h"
+#include "DebugServer2/Host/Platform.h"
+
+#include <asm/ptrace.h>
+#include <elf.h>
+
+#include <cstring>
+
+#define super ds2::Host::POSIX::PTrace
+
+namespace ds2 {
+namespace Host {
+namespace Linux {
+
+ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid, ProcessInfo const &,
+                               Architecture::CPUState &state) {
+  struct user_regs_struct gprs;
+  CHK(readRegisterSet(ptid, NT_PRSTATUS, &gprs, sizeof(gprs)));
+
+  // The layout is identical.
+  std::memcpy(state.gp.regs, &gprs, sizeof(state.gp.regs));
+
+#if __riscv_flen == 32
+  struct __riscv_f_ext_state fprs;
+  CHK(readRegisterSet(ptid, NT_FPREGSET, &fprs, sizeof(fprs)));
+#elif __riscv_flen == 64
+  struct __riscv_d_ext_state fprs;
+  CHK(readRegisterSet(ptid, NT_FPREGSET, &fprs, sizeof(fprs)));
+#elif __riscv_flen == 128
+#error "quad precision floating point support unimplemented"
+#endif
+
+  // The layout is identical.
+  std::memcpy(&state.fp, &fprs, sizeof(state.fp));
+
+  return kSuccess;
+}
+
+ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
+                                ProcessInfo const &,
+                                Architecture::CPUState const &state) {
+  struct user_regs_struct gprs;
+  static_assert(sizeof(gprs) >= sizeof(state.gp.regs),
+                "expected `struct user_regs_struct` to be larger");
+  // The layout is identical.
+  std::memcpy(&gprs, state.gp.regs, sizeof(state.gp.regs));
+
+  CHK(writeRegisterSet(ptid, NT_PRSTATUS, &gprs, sizeof(gprs)));
+
+#if __riscv_flen == 32
+  struct __riscv_f_ext_state fprs;
+  static_assert(sizeof(fprs) >= sizeof(state.fp),
+                "expected `struct __riscv_f_ext_state` to be larger");
+#elif __riscv_flen == 64
+  struct __riscv_d_ext_state fprs;
+  static_assert(sizeof(fprs) >= sizeof(state.fp),
+                "expected `struct __riscv_d_ext_state` to be larger");
+#elif __riscv_flen == 128
+#error "quad precision floating point support unimplemented"
+#endif
+
+  // The layout is identical.
+  std::memcpy(&fprs, &state.fp, sizeof(state.fp));
+
+  CHK(writeRegisterSet(ptid, NT_FPREGSET, &fprs, sizeof(fprs)));
+
+  return kSuccess;
+}
+
+} // namespace Linux
+} // namespace Host
+} // namespace ds2

--- a/Sources/Support/POSIX/ELFSupport.cpp
+++ b/Sources/Support/POSIX/ELFSupport.cpp
@@ -44,6 +44,20 @@ bool ELFSupport::MachineTypeToCPUType(uint32_t machineType, bool is64Bit,
     break;
 #endif
 
+#elif defined(ARCH_RISCV)
+  case EM_RISCV:
+#if __riscv_xlen == 32
+    type = kCPUTypeRISCV32;
+    subType = kCPUSubTypeRISCV32_ALL;
+#elif __riscv_xlen == 64
+    type = kCPUTypeRISCV64;
+    subType = kCPUSubTypeRISCV64_ALL;
+#elif __riscv_xlen == 128
+    type = kCPUTypeRISCV128;
+    subType = kCPUSubTypeRISCV128_ALL;
+#endif
+    break;
+
 #else
 #error "Architecture not supported."
 #endif

--- a/Sources/Target/Common/RISCV/ProcessBaseRISCV.cpp
+++ b/Sources/Target/Common/RISCV/ProcessBaseRISCV.cpp
@@ -1,0 +1,32 @@
+// Copyright 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+
+#include "DebugServer2/Target/ProcessBase.h"
+
+using ds2::Architecture::GDBDescriptor;
+using ds2::Architecture::LLDBDescriptor;
+
+namespace ds2 {
+namespace Target {
+
+GDBDescriptor const *ProcessBase::getGDBRegistersDescriptor() const {
+#if __riscv_xlen == 32
+  return &Architecture::RISCV32::GDB;
+#elif __riscv_xlen == 64
+  return &Architecture::RISCV64::GDB;
+#elif __riscv_xlen == 128
+  return &Architecture::RISCV128::GDB;
+#endif
+}
+
+LLDBDescriptor const *ProcessBase::getLLDBRegistersDescriptor() const {
+#if __riscv_xlen == 32
+  return &Architecture::RISCV32::LLDB;
+#elif __riscv_xlen == 64
+  return &Architecture::RISCV64::LLDB;
+#elif __riscv_xlen == 128
+  return &Architecture::RISCV128::LLDB;
+#endif
+}
+
+} // namespace Target
+} // namespace ds2

--- a/Sources/Target/Linux/RISCV/ProcessRISCV.cpp
+++ b/Sources/Target/Linux/RISCV/ProcessRISCV.cpp
@@ -1,0 +1,117 @@
+// Copyright 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+
+#include "DebugServer2/Target/Process.h"
+#include "DebugServer2/Host/Platform.h"
+#include "DebugServer2/Target/Thread.h"
+
+#include <cmath>
+
+#include <stddef.h>
+#include <syscall.h>
+#include <sys/mman.h>
+
+namespace ds2 {
+namespace Target {
+namespace Linux {
+
+namespace syscalls {
+namespace {
+template <typename T>
+inline void InsertBytes(ByteVector &bytes, T value) {
+  uint8_t *data = reinterpret_cast<uint8_t *>(&value);
+  bytes.insert(std::end(bytes), data, data + sizeof(T));
+}
+
+inline void mmap(size_t size, int protection, ByteVector &code) {
+#if __riscv_xlen == 32
+  DS2BUG("do not know how to mmap on this bitness")
+#elif __riscv_xlen == 64
+  static_assert(sizeof(size) == 8, "size_t should be 8-bytes on RISCV64");
+  static_assert(std::log2(MAP_ANON | MAP_PRIVATE) <= 20, "20-bit immediate");
+  static_assert(std::log2(__NR_mmap) <= 20, "20-bit immediate");
+  DS2ASSERT(std::log2(protection) <= 20);
+
+  for (uint32_t instruction: {
+           static_cast<uint32_t>(0x00004533),                                  // xor a0, zero, zero
+           static_cast<uint32_t>(0x0245b583),                                  // ld a1, .Lsize
+           static_cast<uint32_t>(0x0245b583),                                  //
+           static_cast<uint32_t>(0x00000613 | protection << 20),               // li a2, protection
+           static_cast<uint32_t>(0x00000693 | (MAP_ANON | MAP_PRIVATE) << 20), // li a3, MAP_ANON | MAP_PRIVATE
+           static_cast<uint32_t>(0xfff00713),                                  // li a4, -1
+           static_cast<uint32_t>(0x00000793),                                  // li a5, 0
+           static_cast<uint32_t>(0x00000893 | __NR_mmap << 20),                // li a7, __NR_mmap
+           static_cast<uint32_t>(0x00000073),                                  // ecall
+           static_cast<uint32_t>(0x00100073),                                  // ebreak
+                                                                               // .Lsize:
+                                                                               //    .quad size
+       })
+    InsertBytes(code, instruction);
+  InsertBytes(code, size);
+#elif __riscv_xlen == 128
+  DS2BUG("do not know how to mmap on this bitness")
+#endif
+}
+
+inline void munmap(uintptr_t address, size_t size, ByteVector &code) {
+#if __riscv_xlen == 32
+  DS2BUG("do not know how to munmap on this bitness")
+#elif __riscv_xlen == 64
+  static_assert(sizeof(size) == 8, "size_t should be 8-bytes on RISCV64");
+  static_assert(std::log2(__NR_munmap) <= 20, "20-bit immediate");
+
+  for (uint32_t instruction: {
+           static_cast<uint32_t>(0x00000517),                                  // ld a0, .Laddress
+           static_cast<uint32_t>(0x01c53503),                                  //
+           static_cast<uint32_t>(0x00000597),                                  // ld a1, .Lsize
+           static_cast<uint32_t>(0x01c5b583),                                  //
+           static_cast<uint32_t>(0x00000893 | __NR_munmap << 20),              // li a7, __NR_munmap
+           static_cast<uint32_t>(0x00000073),                                  // ecall
+           static_cast<uint32_t>(0x00100073),                                  // ebreak
+                                                                               // .Laddress:
+                                                                               //    .quad address
+                                                                               // .Lsize:
+                                                                               //    .quad size
+       })
+    InsertBytes(code, instruction);
+  InsertBytes(code, address);
+  InsertBytes(code, size);
+#elif __riscv_xlen == 128
+  DS2BUG("do not know how to munmap on this bitness")
+#endif
+}
+}
+}
+
+ErrorCode Process::allocateMemory(size_t size, uint32_t protection,
+                                  uintptr_t *address) {
+  if (address == nullptr || size == 0)
+    return kErrorInvalidArgument;
+
+  ByteVector code;
+  syscalls::mmap(size, convertMemoryProtectionToPOSIX(protection), code);
+
+  uintptr_t result;
+  CHK(executeCode(code, result));
+  if (static_cast<intptr_t>(result) < 0)
+    return kErrorUnknown;
+  *address = result;
+  return kSuccess;
+}
+
+ErrorCode Process::deallocateMemory(uintptr_t address, size_t size) {
+  if (size == 0)
+    return kErrorInvalidArgument;
+
+  ByteVector code;
+  syscalls::munmap(address, size, code);
+
+  uintptr_t result;
+  CHK(executeCode(code, result));
+  if (static_cast<intptr_t>(result) < 0)
+    return kErrorUnknown;
+  return kSuccess;
+}
+
+} // namespace Linux
+} // namespace Target
+} // namespace ds2

--- a/Sources/Target/POSIX/Thread.cpp
+++ b/Sources/Target/POSIX/Thread.cpp
@@ -11,6 +11,8 @@
 #include "DebugServer2/Target/POSIX/Thread.h"
 #if defined(ARCH_ARM)
 #include "DebugServer2/Architecture/ARM/SoftwareSingleStep.h"
+#elif defined(ARCH_RISCV)
+#include "DebugServer2/Architecture/RISCV/SoftwareSingleStep.h"
 #endif
 #include "DebugServer2/Target/Process.h"
 


### PR DESCRIPTION
This adds the rv{32,64,128} skeleton in place so that we can start adding the
necessary architectural support.