### PR TITLE
Core: wire through the address for breakpoint selection

### DIFF
--- a/Headers/DebugServer2/Core/BreakpointManager.h
+++ b/Headers/DebugServer2/Core/BreakpointManager.h
@@ -83,7 +83,7 @@ public:
 protected:
   virtual ErrorCode isValid(Address const &address, size_t size,
                             Mode mode) const;
-  virtual size_t chooseBreakpointSize() const = 0;
+  virtual size_t chooseBreakpointSize(Address const &address) const = 0;
 
 protected:
   friend Target::ProcessBase;

--- a/Headers/DebugServer2/Core/HardwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/HardwareBreakpointManager.h
@@ -51,7 +51,7 @@ public:
 protected:
   ErrorCode isValid(Address const &address, size_t size,
                     Mode mode) const override;
-  size_t chooseBreakpointSize() const override;
+  size_t chooseBreakpointSize(Address const &address) const override;
 
 protected:
   virtual int getAvailableLocation();

--- a/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
@@ -44,7 +44,7 @@ public:
 protected:
   ErrorCode isValid(Address const &address, size_t size,
                     Mode mode) const override;
-  size_t chooseBreakpointSize() const override;
+  size_t chooseBreakpointSize(Address const &address) const override;
 
 #if defined(ARCH_ARM) || defined(ARCH_ARM64)
 public:

--- a/Sources/Core/ARM/HardwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/HardwareBreakpointManager.cpp
@@ -41,7 +41,7 @@ ErrorCode HardwareBreakpointManager::isValid(Address const &address,
   return kErrorUnsupported;
 }
 
-size_t HardwareBreakpointManager::chooseBreakpointSize() const {
+size_t HardwareBreakpointManager::chooseBreakpointSize(Address const &) const {
   DS2BUG(
       "Choosing a hardware breakpoint size on ARM is an unsupported operation");
 }

--- a/Sources/Core/ARM/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/SoftwareBreakpointManager.cpp
@@ -177,7 +177,7 @@ ErrorCode SoftwareBreakpointManager::isValid(Address const &address,
   return super::isValid(address, size, mode);
 }
 
-size_t SoftwareBreakpointManager::chooseBreakpointSize() const {
+size_t SoftwareBreakpointManager::chooseBreakpointSize(Address const &) const {
   DS2BUG(
       "Choosing a software breakpoint size on ARM is an unsupported operation");
 }

--- a/Sources/Core/BreakpointManager.cpp
+++ b/Sources/Core/BreakpointManager.cpp
@@ -27,7 +27,7 @@ ErrorCode BreakpointManager::add(Address const &address, Lifetime lifetime,
   CHK(isValid(address, size, mode));
 
   if (size == 0) {
-    size = chooseBreakpointSize();
+    size = chooseBreakpointSize(address);
   }
 
   auto it = _sites.find(address);

--- a/Sources/Core/X86/HardwareBreakpointManager.cpp
+++ b/Sources/Core/X86/HardwareBreakpointManager.cpp
@@ -236,7 +236,7 @@ ErrorCode HardwareBreakpointManager::isValid(Address const &address,
   return super::isValid(address, size, mode);
 }
 
-size_t HardwareBreakpointManager::chooseBreakpointSize() const {
+size_t HardwareBreakpointManager::chooseBreakpointSize(Address const &) const {
   DS2BUG(
       "Choosing a hardware breakpoint size on x86 is an unsupported operation");
 }

--- a/Sources/Core/X86/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/X86/SoftwareBreakpointManager.cpp
@@ -65,7 +65,7 @@ ErrorCode SoftwareBreakpointManager::isValid(Address const &address,
   return super::isValid(address, size, mode);
 }
 
-size_t SoftwareBreakpointManager::chooseBreakpointSize() const {
+size_t SoftwareBreakpointManager::chooseBreakpointSize(Address const &) const {
   // On x86 and x86_64, software breakpoints will always be of size 1
   return 1;
 }


### PR DESCRIPTION
When selecting the size of the breakpoint, the target requires knowledge
of the breakpoint location to make the size determination.  This will be
used in the RISCV support subsequently.