### PR TITLE
Headers: add some missing includes

### DIFF
--- a/Headers/DebugServer2/Utils/Enums.h
+++ b/Headers/DebugServer2/Utils/Enums.h
@@ -8,6 +8,8 @@
 // PATENTS file in the same directory.
 //
 
+#include <type_traits>
+
 template <typename Enum> struct EnableBitMaskOperators {
   static const bool enable = false;
 };

--- a/Headers/DebugServer2/Utils/HexValues.h
+++ b/Headers/DebugServer2/Utils/HexValues.h
@@ -12,6 +12,7 @@
 
 #include "DebugServer2/Utils/CompilerSupport.h"
 #include "DebugServer2/Utils/Log.h"
+#include "DebugServer2/Types.h"
 
 #include <cstdint>
 #include <cstdio>

--- a/Headers/DebugServer2/Utils/MPL.h
+++ b/Headers/DebugServer2/Utils/MPL.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <utility>
+
 namespace ds2 {
 namespace Utils {
 

--- a/Headers/DebugServer2/Utils/ScopedJanitor.h
+++ b/Headers/DebugServer2/Utils/ScopedJanitor.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <utility>
+
 namespace ds2 {
 namespace Utils {
 

--- a/Headers/DebugServer2/Utils/SwapEndian.h
+++ b/Headers/DebugServer2/Utils/SwapEndian.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace ds2 {
 
 static constexpr uint16_t Swap16(uint16_t x) { return (x >> 8) | (x << 8); }


### PR DESCRIPTION
This makes the headers more standalone and easier to work with.  These changes
would be needed to enable modular builds.