### PR TITLE
build: disable STL exceptions on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ set(CMAKE_CXX_EXTENSIONS NO)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if(CMAKE_SYSTEM_NAME MATCHES Windows)
+  # NOTE(compnerd) disable exceptions in STL
+  add_compile_definitions(_HAS_EXCEPTIONS=0)
+endif()
+
 set(OS_NAME ${CMAKE_SYSTEM_NAME})
 
 string(STRIP "${OS_NAME}" OS_NAME)


### PR DESCRIPTION
The default behaviour of the C++ standard template library on MSVC is to enable
exceptions.  However, because we do not use exceptions, ensure that we indicate
that exceptions should be disabled.