### PR TITLE
Headers: add a missing `#pragma once`

### DIFF
--- a/Headers/DebugServer2/Utils/Enums.h
+++ b/Headers/DebugServer2/Utils/Enums.h
@@ -8,6 +8,8 @@
 // PATENTS file in the same directory.
 //
 
+#pragma once
+
 #include <type_traits>
 
 template <typename Enum> struct EnableBitMaskOperators {


### PR DESCRIPTION
This protects from redefinitions should the header be included in more than one
location.