### PR TITLE
Windows: use C++ standard attribute

### DIFF
--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -177,7 +177,7 @@ void Thread::updateState(DEBUG_EVENT const &de) {
     default:
       DS2LOG(Warning, "unsupported exception code: %lx",
              de.u.Exception.ExceptionRecord.ExceptionCode);
-      [[gnu::fallthrough]];
+      [[fallthrough]];
 
     case STATUS_INVALID_DISPOSITION:
     case STATUS_NONCONTINUABLE_EXCEPTION:


### PR DESCRIPTION
`[[fallthrough]]` was standardized in C++17, use that over
`[[gnu::fallthrough]]`.  This should silence a wanring on Windows.