### PR TITLE
X86: silence a warning on Windows x86

### DIFF
--- a/Sources/Core/X86/HardwareBreakpointManager.cpp
+++ b/Sources/Core/X86/HardwareBreakpointManager.cpp
@@ -190,7 +190,7 @@ int HardwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
 
   int regIdx = -1;
   for (size_t i = 0; i < maxWatchpoints(); ++i) {
-    if (debugRegs[kStatusRegIdx] & (1 << i)) {
+    if (debugRegs[kStatusRegIdx] & (1ull << i)) {
       DS2ASSERT(_locations[i] != 0);
       site = _sites.find(_locations[i])->second;
       regIdx = i;


### PR DESCRIPTION
Explicitly type the constant `1` to an `unsigned long long` during the shift
operation to construct the mask against a `uint64_t`.  This should silecne a
warning on 32-bit Windows.