### PR TITLE
GDBRemote: use `DS2BUG` rather than `DS2ASSERT`

### DIFF
--- a/Sources/GDBRemote/DummySessionDelegateImpl.cpp
+++ b/Sources/GDBRemote/DummySessionDelegateImpl.cpp
@@ -31,8 +31,7 @@ namespace GDBRemote {
 DummySessionDelegateImpl::DummySessionDelegateImpl() = default;
 
 size_t DummySessionDelegateImpl::getGPRSize() const {
-  DS2ASSERT(!"this method shall be implemented by inheriting class");
-  return 0;
+  DS2BUG("this method shall be implemented by inheriting class");
 }
 
 ErrorCode DummySessionDelegateImpl::onEnableExtendedMode(Session &) {


### PR DESCRIPTION
This should ensure that we always print the error message and mark the path
unreachable.  This alows avoids an unnecessary warning with clang and
`-Wstring-conversion` which objects to the conversion of the string to a bool.