### PR TITLE
Replace `DS2_FALLTHROUGH` with standard `[[fallthrough]]`

### DIFF
--- a/Headers/DebugServer2/Utils/CompilerSupport.h
+++ b/Headers/DebugServer2/Utils/CompilerSupport.h
@@ -27,18 +27,6 @@
 #define DS2_ATTRIBUTE_PRINTF(FORMAT, START)
 #endif
 
-#if defined(COMPILER_GCC)
-#if __GNUC__ > 6
-#define DS2_FALLTHROUGH [[fallthrough]]
-#else
-#define DS2_FALLTHROUGH
-#endif
-#elif defined(COMPILER_CLANG)
-#define DS2_FALLTHROUGH [[clang::fallthrough]]
-#else
-#define DS2_FALLTHROUGH
-#endif
-
 #if defined(COMPILER_MSVC)
 #define DS2_ATTRIBUTE_PACKED "DS2_ATTRIBUTE_PACKED not implemented on MSVC"
 #elif defined(COMPILER_GCC) || defined(COMPILER_CLANG)

--- a/Sources/Core/X86/HardwareBreakpointManager.cpp
+++ b/Sources/Core/X86/HardwareBreakpointManager.cpp
@@ -210,7 +210,7 @@ ErrorCode HardwareBreakpointManager::isValid(Address const &address,
     break;
   case 8:
     DS2LOG(Warning, "8-byte breakpoints not supported on all architectures");
-    DS2_FALLTHROUGH;
+    [[fallthrough]];
 
   case 2:
   case 4:

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -189,9 +189,8 @@ ErrorCode DebugSessionImplBase::queryStopInfo(Session &session, Thread *thread,
   case StopInfo::kEventNone:
     stop.event = StopInfo::kEventStop;
     stop.reason = StopInfo::kReasonNone;
-    DS2_FALLTHROUGH;
+    [[fallthrough]];
 
-  // fall-through from kEventNone.
   case StopInfo::kEventStop: {
     // Thread name won't be available if the process has exited or has been
     // killed.

--- a/Sources/Host/POSIX/ProcessSpawner.cpp
+++ b/Sources/Host/POSIX/ProcessSpawner.cpp
@@ -355,9 +355,9 @@ ErrorCode ProcessSpawner::run(std::function<bool()> preExecAction) {
 
   for (size_t n = 0; n < 3; n++) {
     switch (_descriptors[n].mode) {
-    // intentional fall-through to kRedirectConsole
     case kRedirectUnset:
       _descriptors[n].mode = kRedirectConsole;
+      [[fallthrough]];
     case kRedirectConsole:
       // do nothing
       break;
@@ -390,10 +390,10 @@ ErrorCode ProcessSpawner::run(std::function<bool()> preExecAction) {
 
     case kRedirectBuffer:
       _outputBuffer.clear();
-    // fall-through
+      [[fallthrough]];
     case kRedirectDelegate:
       startRedirectThread = true;
-    // fall-through
+      [[fallthrough]];
     case kRedirectTerminal:
       if (term[RD] == -1) {
         if (!open_terminal(term)) {


### PR DESCRIPTION
With C++17, we have the `[[fallthrough]]` attribute to indicate a fallthrough on
a switch case.  Adopt that consistently and apply it to a few sites that were
missing the attribute.