### PR TITLE
Sweep up some lingering warnings from clang/libc++

### DIFF
--- a/Sources/Architecture/RISCV/SoftwareSingleStep.cpp
+++ b/Sources/Architecture/RISCV/SoftwareSingleStep.cpp
@@ -11,7 +11,7 @@ namespace {
 template <size_t Width>
 uintptr_t sext(uintptr_t value) {
   return ((value & (1 << Width)) ? ~((value & (1 << Width)) - 1) : 0) |
-         (value & ((1 << Width + 1) - 1));
+         (value & ((1 << (Width + 1)) - 1));
 }
 }
 

--- a/Sources/Architecture/RISCV/SoftwareSingleStep.cpp
+++ b/Sources/Architecture/RISCV/SoftwareSingleStep.cpp
@@ -142,6 +142,7 @@ ErrorCode PrepareSoftwareSingleStep(Target::Process *process,
         break;
       }
       }
+      break;
     case 0x02:
       switch ((instruction & 0xf000) >> 12) {
       default: break;

--- a/Sources/Target/Linux/RISCV/ProcessRISCV.cpp
+++ b/Sources/Target/Linux/RISCV/ProcessRISCV.cpp
@@ -27,8 +27,8 @@ inline void mmap(size_t size, int protection, ByteVector &code) {
   DS2BUG("do not know how to mmap on this bitness")
 #elif __riscv_xlen == 64
   static_assert(sizeof(size) == 8, "size_t should be 8-bytes on RISCV64");
-  static_assert(std::log2(MAP_ANON | MAP_PRIVATE) <= 20, "20-bit immediate");
-  static_assert(std::log2(__NR_mmap) <= 20, "20-bit immediate");
+  DS2ASSERT(std::log2(MAP_ANON | MAP_PRIVATE) <= 20);
+  DS2ASSERT(std::log2(__NR_mmap) <= 20);
   DS2ASSERT(std::log2(protection) <= 20);
 
   for (uint32_t instruction: {
@@ -57,7 +57,7 @@ inline void munmap(uintptr_t address, size_t size, ByteVector &code) {
   DS2BUG("do not know how to munmap on this bitness")
 #elif __riscv_xlen == 64
   static_assert(sizeof(size) == 8, "size_t should be 8-bytes on RISCV64");
-  static_assert(std::log2(__NR_munmap) <= 20, "20-bit immediate");
+  DS2ASSERT(std::log2(__NR_munmap) <= 20);
 
   for (uint32_t instruction: {
            static_cast<uint32_t>(0x00000517),                                  // ld a0, .Laddress


### PR DESCRIPTION
This cleans up a few warnings and build issues identified with a build of ds2 on RISCV with clang/libc++ .