### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,15 +21,15 @@ jobs:
         run: choco install winflexbison3
 
       - name: Configure
-        run: cmake -B ${{ github.workspace }}/build -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake -D CMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A ${{ matrix.arch }} -S ${{ github.workspace }}
+        run: cmake -B ${{ github.workspace }}/BinaryCache/ds2 -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake -D CMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A ${{ matrix.arch }} -S ${{ github.workspace }}
       - name: Build
-        run: cmake --build ${{ github.workspace }}/build --config Release
+        run: cmake --build ${{ github.workspace }}/BinaryCache/ds2 --config Release
 
       - uses: actions/upload-artifact@v2
         with:
           name: windows-${{ matrix.arch }}-ds2
           path: |
-            build/Release/ds2.exe
+            ${{ github.workspace }}/BinaryCache/ds2/Release/ds2.exe
 
 
   mingw:
@@ -60,15 +60,15 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Configure
-        run: cmake -B $(cygpath -u '${{ github.workspace }}/build') -C $(cygpath -u '${{ github.workspace }}/cmake/caches/GNUWarnings.cmake') -D CMAKE_BUILD_TYPE=Release -G Ninja -S $(cygpath -u '${{ github.workspace }}')
+        run: cmake -B $(cygpath -u '${{ github.workspace }}/BinaryCache/ds2') -C $(cygpath -u '${{ github.workspace }}/cmake/caches/GNUWarnings.cmake') -D CMAKE_BUILD_TYPE=Release -G Ninja -S $(cygpath -u '${{ github.workspace }}')
       - name: Build
-        run: cmake --build $(cygpath -u '${{ github.workspace }}/build') --config Release
+        run: cmake --build $(cygpath -u '${{ github.workspace }}/BinaryCache/ds2') --config Release
 
       - uses: actions/upload-artifact@v2
         with:
           name: mingw-${{ matrix.system }}-ds2
           path: |
-            build/Release/ds2.exe
+            ${{ github.workspace }}/BinaryCache/ds2/Release/ds2.exe
 
   macos:
     runs-on: macos-latest
@@ -78,15 +78,15 @@ jobs:
       - uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Configure
-        run: cmake -B ${{ github.workspace }}/out -C ${{ github.workspace }}/cmake/caches/ClangWarnings.cmake -D CMAKE_BUILD_TYPE=Release -G Ninja -S ${{ github.workspace }}
+        run: cmake -B ${{ github.workspace }}/BinaryCache/ds2 -C ${{ github.workspace }}/cmake/caches/ClangWarnings.cmake -D CMAKE_BUILD_TYPE=Release -G Ninja -S ${{ github.workspace }}
       - name: Build
-        run: cmake --build ${{ github.workspace }}/out --config Release
+        run: cmake --build ${{ github.workspace }}/BinaryCache/ds2 --config Release
 
       - uses: actions/upload-artifact@v2
         with:
           name: macOS-x86_64-ds2
           path: |
-            build/ds2
+            ${{ github.workspace }}/BinaryCache/ds2/ds2
 
   linux:
     runs-on: ubuntu-latest
@@ -105,12 +105,12 @@ jobs:
           sudo apt-get install -qq --no-install-recommends bison flex gcc-multilib g++-multilib ninja-build
 
       - name: Configure
-        run: cmake -B ${{ github.workspace }}/build -C ${{ github.workspace }}/cmake/caches/GNUWarnings.cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_SYSTEM_NAME=Linux -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.processor }} -D CMAKE_C_FLAGS=${{ matrix.cflags }} -D CMAKE_CXX_FLAGS=${{ matrix.cxxflags }} -G Ninja -S ${{ github.workspace }}
+        run: cmake -B ${{ github.workspace }}/BinaryCache/ds2 -C ${{ github.workspace }}/cmake/caches/GNUWarnings.cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_SYSTEM_NAME=Linux -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.processor }} -D CMAKE_C_FLAGS=${{ matrix.cflags }} -D CMAKE_CXX_FLAGS=${{ matrix.cxxflags }} -G Ninja -S ${{ github.workspace }}
       - name: Build
-        run: cmake --build ${{ github.workspace }}/build --config Releaase
+        run: cmake --build ${{ github.workspace }}/BinaryCache/ds2 --config Releaase
 
       - uses: actions/upload-artifact@v2
         with:
           name: linux-${{ matrix.processor }}-ds2
           path: |
-            build/ds2
+            ${{ github.workspace }}/BinaryCache/ds2/ds2


### PR DESCRIPTION
Homogenize the build directory across the various builds.  This is primarily motivated by the desire to add a bazel based build which uses BUILD making the build directory unusable on case sensitive file systems (Windows, Darwin).  This should fix an issue in the Darwin builds not uploading results.