### PR TITLE
Host: support character devices on POSIX platforms

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -252,6 +252,7 @@ filegroup(
             "Headers/DebugServer2/Target/Windows/Thread.h",
         ],
         ("@platforms//os:android", "@platforms//os:freebsd", "@platforms//os:linux", "@platforms//os:macos"): [
+            "Headers/DebugServer2/Host/POSIX/HandleChannel.h",
             "Headers/DebugServer2/Host/POSIX/PTrace.h",
             "Headers/DebugServer2/Host/POSIX/ProcessSpawner.h",
             "Headers/DebugServer2/Target/POSIX/Process.h",
@@ -402,6 +403,7 @@ filegroup(
         ],
         ("@platforms//os:android", "@platforms//os:freebsd", "@platforms//os:linux", "@platforms//os:macos"): [
             "Sources/Host/POSIX/File.cpp",
+            "Sources/Host/POSIX/HandleChannel.cpp",
             "Sources/Host/POSIX/Platform.cpp",
             "Sources/Host/POSIX/ProcessSpawner.cpp",
             "Sources/Host/POSIX/PTrace.cpp",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,7 @@ else()
   # Assumes that any non-Windows platform is POSIX.
   target_sources(ds2 PRIVATE
     Sources/Host/POSIX/File.cpp
+    Sources/Host/POSIX/HandleChannel.cpp
     Sources/Host/POSIX/Platform.cpp
     Sources/Host/POSIX/ProcessSpawner.cpp
     Sources/Host/POSIX/PTrace.cpp

--- a/Headers/DebugServer2/Host/POSIX/HandleChannel.h
+++ b/Headers/DebugServer2/Host/POSIX/HandleChannel.h
@@ -1,0 +1,38 @@
+// Copyright 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+
+#pragma once
+
+#include "DebugServer2/Host/Channel.h"
+
+namespace ds2 {
+namespace Host {
+
+class HandleChannel : public Channel {
+  int fd_;
+
+public:
+  HandleChannel() : fd_(-1) {}
+  HandleChannel(int fd);
+  ~HandleChannel() override;
+
+  HandleChannel(const HandleChannel &) = delete;
+  HandleChannel(HandleChannel &&other) : fd_(other.fd_) {
+    other.fd_ = -1;
+  }
+
+public:
+  void close() override;
+
+public:
+  bool connected() const override { return fd_ >= 0; }
+
+public:
+  bool wait(int ms = -1) override;
+
+public:
+  ssize_t send(void const *buffer, size_t length) override;
+  ssize_t receive(void *buffer, size_t length) override;
+};
+
+}
+}

--- a/Sources/Host/POSIX/HandleChannel.cpp
+++ b/Sources/Host/POSIX/HandleChannel.cpp
@@ -1,0 +1,63 @@
+// Copyright 2022 Saleem Abdulrasool <compnerd@compnerd.org>
+
+#include "DebugServer2/Host/POSIX/HandleChannel.h"
+
+#include <fcntl.h>
+#include <poll.h>
+
+namespace ds2 {
+namespace Host {
+
+HandleChannel::HandleChannel(int fd) : fd_(fd) {
+  int flags = ::fcntl(fd_, F_GETFL, 0);
+  ::fcntl(fd_, F_SETFL, flags | O_NONBLOCK);
+}
+
+HandleChannel::~HandleChannel() {
+  close();
+}
+
+void HandleChannel::close() {
+  if (fd_ >= 0)
+    ::close(fd_);
+  fd_ = -1;
+}
+
+bool HandleChannel::wait(int ms) {
+  if (fd_ < 0)
+    return false;
+
+  struct pollfd fds;
+  fds.fd = fd_;
+  fds.events = POLLIN;
+  int nfds = ::poll(&fds, 1, ms);
+  return nfds == 1 && (fds.revents & POLLIN);
+}
+
+ssize_t HandleChannel::send(void const *buffer, size_t length) {
+  if (fd_ < 0)
+    return -1;
+
+  if (ssize_t nwritten =
+          ::write(fd_, reinterpret_cast<const char *>(buffer), length);
+      nwritten > 0)
+    return nwritten;
+
+  close();
+  return -1;
+}
+
+ssize_t HandleChannel::receive(void *buffer, size_t length) {
+  if (fd_ < 0)
+    return -1;
+
+  if (length == 0)
+    return 0;
+
+  ssize_t nread = ::read(fd_, reinterpret_cast<char *>(buffer), length);
+  if (nread == 0)
+    close();
+  return nread > 0 ? nread : 0;
+}
+}
+}


### PR DESCRIPTION
Introduce a new `HandleChannel` type that creates a channel from a handle.  This
allows us to create a channel to a serial port device.  Wire this up in main to
get a channel to the physical device, enabling serial port support.