### PR TITLE
POSIX: adjust the alt stack buffer

### DIFF
--- a/Sources/Utils/POSIX/FaultHandler.cpp
+++ b/Sources/Utils/POSIX/FaultHandler.cpp
@@ -31,11 +31,16 @@ private:
   }
 
   void installCatcher() {
+#if defined(__APPLE__)
+    long sz = SIGSTKSZ;
+    static std::unique_ptr<char[]> alt = std::make_unique<char[]>(sz);
+#else
     long sz = sysconf(_SC_SIGSTKSZ);
     if (sz == -1)
       abort();
 
     static std::unique_ptr<char[]> alt = std::make_unique<char[]>(sz);
+#endif
     struct sigaction sa;
     stack_t ss;
 

--- a/Sources/Utils/POSIX/FaultHandler.cpp
+++ b/Sources/Utils/POSIX/FaultHandler.cpp
@@ -35,7 +35,7 @@ private:
     if (sz == -1)
       abort("unable to query signal stack size");
 
-    static std::unique_ptr<char*> alt = std::make_unique<char*>(sz);
+    static std::unique_ptr<char[]> alt = std::make_unique<chari[]>(sz);
     struct sigaction sa;
     stack_t ss;
 

--- a/Sources/Utils/POSIX/FaultHandler.cpp
+++ b/Sources/Utils/POSIX/FaultHandler.cpp
@@ -33,9 +33,9 @@ private:
   void installCatcher() {
     long sz = sysconf(_SC_SIGSTKSZ);
     if (sz == -1)
-      abort("unable to query signal stack size");
+      abort();
 
-    static std::unique_ptr<char[]> alt = std::make_unique<chari[]>(sz);
+    static std::unique_ptr<char[]> alt = std::make_unique<char[]>(sz);
     struct sigaction sa;
     stack_t ss;
 


### PR DESCRIPTION
Glibc 2.34+ renames `SIGSTKSZ` to a `sysconf` query.  Use that to dynamically query and allocate the buffer as a dynamically allocated static managed buffer.