### PR TITLE
Core: rename a parameter (NFC)

### DIFF
--- a/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
@@ -29,7 +29,7 @@ public:
   virtual int hit(Target::Thread *thread, Site &site) override;
 
 protected:
-  virtual void getOpcode(uint32_t type, ByteVector &opcode) const;
+  virtual void getOpcode(size_t size, ByteVector &opcode) const;
 
 protected:
   virtual ErrorCode enableLocation(Site const &site,

--- a/Sources/Core/ARM/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/SoftwareBreakpointManager.cpp
@@ -104,16 +104,16 @@ int SoftwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
 #endif
 }
 
-void SoftwareBreakpointManager::getOpcode(uint32_t type,
+void SoftwareBreakpointManager::getOpcode(size_t size,
                                           ByteVector &opcode) const {
 #if defined(OS_WIN32) && defined(ARCH_ARM)
-  if (type == 4) {
+  if (size == 4) {
     static const uint32_t WinARMBPType = 2;
     DS2LOG(Warning,
            "requesting a breakpoint of size %u on Windows ARM, "
-           "adjusting to type %u",
-           type, WinARMBPType);
-    type = WinARMBPType;
+           "adjusting to size %u",
+           size, WinARMBPType);
+    size = WinARMBPType;
   }
 #endif
 
@@ -121,7 +121,7 @@ void SoftwareBreakpointManager::getOpcode(uint32_t type,
 
   // TODO: We shouldn't have preprocessor checks for ARCH_ARM vs ARCH_ARM64
   // because we might be an ARM64 binary debugging an ARM inferior.
-  switch (type) {
+  switch (size) {
 #if defined(ARCH_ARM)
   case 2: // udf #1
     opcode.push_back('\xde');
@@ -152,8 +152,8 @@ void SoftwareBreakpointManager::getOpcode(uint32_t type,
     break;
 #endif
   default:
-    DS2LOG(Error, "invalid breakpoint type %d", type);
-    DS2BUG("invalid breakpoint type");
+    DS2LOG(Error, "unsupported breakpoint width '%zu'", size);
+    DS2BUG("unsupported breakpoint width");
     break;
   }
 

--- a/Sources/Core/RISCV/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/RISCV/SoftwareBreakpointManager.cpp
@@ -14,11 +14,11 @@ int SoftwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
   return super::hit(state.pc(), site) ? 0 : -1;
 }
 
-void SoftwareBreakpointManager::getOpcode(uint32_t type,
+void SoftwareBreakpointManager::getOpcode(size_t size,
                                           ByteVector &opcode) const {
   opcode.clear();
 
-  switch (type) {
+  switch (size) {
   case 2: // c.ebreak
     opcode.push_back('\x02');
     opcode.push_back('\x90');
@@ -30,7 +30,7 @@ void SoftwareBreakpointManager::getOpcode(uint32_t type,
     opcode.push_back('\x00');
     break;
   default:
-    DS2LOG(Error, "unsupported breakpoint width '%u'", type);
+    DS2LOG(Error, "unsupported breakpoint width '%zu'", size);
     DS2BUG("unsupported breakpoint width");
     break;
   }

--- a/Sources/Core/X86/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/X86/SoftwareBreakpointManager.cpp
@@ -47,9 +47,9 @@ int SoftwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
   return -1;
 }
 
-void SoftwareBreakpointManager::getOpcode(uint32_t type,
+void SoftwareBreakpointManager::getOpcode(size_t size,
                                           ByteVector &opcode) const {
-  DS2ASSERT(type == 1);
+  DS2ASSERT(size == 1);
   opcode.clear();
   opcode.push_back('\xcc'); // int 3
 }


### PR DESCRIPTION
The parameter `type` in the software breakpoint manager indicates the length of the instruction sequence.  Rename the parameter to `size` to reflect that.