### PR TITLE
DS2: adjust type for `GetSidSubAuthorityCount` result

### DIFF
--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -239,7 +239,7 @@ inline BOOL AllocateAndCopySid(const PSID pSid, PSID *ppSid) noexcept {
   if (!IsValidSid(pSid))
     return CreateWellKnownSid(WinNullSid, nullptr, ppSid, nullptr);
 
-  DWORD nSubAuthorityCount = *GetSidSubAuthorityCount(pSid);
+  UCHAR nSubAuthorityCount = *GetSidSubAuthorityCount(pSid);
   return AllocateAndInitializeSid(GetSidIdentifierAuthority(pSid),
                                   nSubAuthorityCount,
                                   nSubAuthorityCount > 0 ? *GetSidSubAuthority(pSid, 0) : 0,


### PR DESCRIPTION
`GetSidSubAuthorityCount` returns a `PUCHAR`, adjust the storage to use the appropriate type rather than the `DWORD` which widens the result unnecessarily (and subsequently needs to be truncated for the calls in the construction of the SID.