### PR TITLE
ds2: symbolize and emit file:line information in backtraces on windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ if ("${OS_NAME}" MATCHES "FreeBSD")
 endif ()
 
 if ("${OS_NAME}" MATCHES "Windows")
-  target_link_libraries(ds2 PRIVATE shlwapi ws2_32)
+  target_link_libraries(ds2 PRIVATE shlwapi ws2_32 dbghelp)
   if ("${CMAKE_LINKER}" MATCHES "lld")
     target_link_libraries(ds2 PRIVATE advapi32)
   endif()


### PR DESCRIPTION
### Before
```
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b119d05
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b11aada
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b11a52c
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b09218c
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b091897
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b0d5bed
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b0c486b
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b0c525e
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b100538
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b0530ba
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b0546e8
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b054c0d
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b162ea9
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b162d8e
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b162c4e
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007ff72b162f3e
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007fff779826ad
[22776][ds2::Utils::PrintBacktraceEntrySimple] ERROR  : 0x00007fff78feaa68
```

### After
```
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bda9d05 ds2::Utils::PrintBacktrace +0x105 (C:\Users\Ami\src\SourceCache\ds2\Sources\Utils\Backtrace.cpp:134)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bdaaada ds2::vLog +0x50a (C:\Users\Ami\src\SourceCache\ds2\Sources\Utils\Log.cpp:184)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bdaa52c ds2::Log +0x5c (C:\Users\Ami\src\SourceCache\ds2\Sources\Utils\Log.cpp:194)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bd2218c ds2::GDBRemote::DebugSessionImplBase::queryStopInfo +0x2ac (C:\Users\Ami\src\SourceCache\ds2\Sources\GDBRemote\DebugSessionImpl.cpp:207)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bd21897 ds2::GDBRemote::DebugSessionImplBase::onTerminate +0xc7 (C:\Users\Ami\src\SourceCache\ds2\Sources\GDBRemote\DebugSessionImpl.cpp:1036)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bd65bed ds2::GDBRemote::Session::Handle_k +0xdd (C:\Users\Ami\src\SourceCache\ds2\Sources\GDBRemote\Session.cpp:896)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bd5486b ds2::GDBRemote::ProtocolInterpreter::onCommand +0x23b (C:\Users\Ami\src\SourceCache\ds2\Sources\GDBRemote\ProtocolInterpreter.cpp:182)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bd5525e ds2::GDBRemote::ProtocolInterpreter::onPacketData +0x4ae (C:\Users\Ami\src\SourceCache\ds2\Sources\GDBRemote\ProtocolInterpreter.cpp:141)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bd90538 ds2::GDBRemote::SessionBase::receive +0x178 (C:\Users\Ami\src\SourceCache\ds2\Sources\GDBRemote\SessionBase.cpp:58)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bce30ba RunDebugServer +0xfa (C:\Users\Ami\src\SourceCache\ds2\Sources\main.cpp:214)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bce46e8 GdbserverMain +0x1178 (C:\Users\Ami\src\SourceCache\ds2\Sources\main.cpp:502)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bce4c0d main +0x6d (C:\Users\Ami\src\SourceCache\ds2\Sources\main.cpp:650)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bdf2ea9 invoke_main +0x39 (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:79)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bdf2d8e __scrt_common_main_seh +0x12e (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bdf2c4e __scrt_common_main +0xe (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:331)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007ff60bdf2f3e mainCRTStartup +0xe (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:17)
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007fff779826ad BaseThreadInitThunk +0x1d
[12508][ds2::Utils::PrintBacktrace] INFO   : 0x00007fff78feaa68 RtlUserThreadStart +0x28
```