### PR TITLE
Unbreak breakpoint setting on Windows.

### DIFF
--- a/Headers/DebugServer2/Target/Windows/Process.h
+++ b/Headers/DebugServer2/Target/Windows/Process.h
@@ -56,8 +56,6 @@ private:
                                std::vector<MemoryRegionInfo> &modifiedRegions);
   ErrorCode
   restoreRegionsProtection(const std::vector<MemoryRegionInfo> &regions);
-  ErrorCode getMemoryRegionInfoInternal(Address const &address,
-                                        MemoryRegionInfo &info);
 
 protected:
   DWORD convertMemoryProtectionToWindows(uint32_t protection) const;
@@ -65,9 +63,7 @@ protected:
 
 public:
   ErrorCode getMemoryRegionInfo(Address const &address,
-                                MemoryRegionInfo &info) override {
-    return kErrorUnsupported;
-  }
+                                MemoryRegionInfo &info) override;
 
 public:
   ErrorCode updateInfo() override;

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -388,8 +388,7 @@ Process::convertMemoryProtectionFromWindows(DWORD winProtection) const {
   }
 }
 
-// TODO: rename this function to getMemoryRegionInfo and make lldb work with it
-ErrorCode Process::getMemoryRegionInfoInternal(Address const &address,
+ErrorCode Process::getMemoryRegionInfo(Address const &address,
                                                MemoryRegionInfo &region) {
   _MEMORY_BASIC_INFORMATION64 mem;
   SIZE_T bytesQuery = VirtualQueryEx(
@@ -426,7 +425,7 @@ Process::makeMemoryWritable(Address const &address, size_t length,
 
   while (startAddress < endAddress) {
     MemoryRegionInfo region;
-    CHK(getMemoryRegionInfoInternal(address, region));
+    CHK(getMemoryRegionInfo(address, region));
 
     if (!region.protection || !(region.protection & kProtectionWrite)) {
       LPVOID allocError = VirtualAllocEx(
@@ -590,13 +589,10 @@ ErrorCode Process::enumerateSharedLibraries(
       return Platform::TranslateError();
     sl.path = ds2::Utils::WideToNarrowString(std::wstring(nameStr, nameSize));
 
-    // The following two transforms ensure that the paths we return to the
+    // The following transform ensures that the paths we return to the
     // debugger look like unix paths. This shouldn't be required but LLDB seems
     // to be having trouble with paths when the host and the remote don't use
     // the same path separator.
-    if (sl.path.length() >= 2 && sl.path[0] >= 'A' && sl.path[0] <= 'Z' &&
-        sl.path[1] == ':')
-      sl.path.erase(0, 2);
     for (auto &c : sl.path)
       if (c == '\\')
         c = '/';


### PR DESCRIPTION
getMemoryRegionInfoInternal was already doing what getMemoryRegionInfo needs to do for lldb, so promoted it.

Path comparisons were failing during Handle_qFileLoadAddress because lldb was asking for paths like "C:/path/to/file.exe" while ds2 was dropping the leading "C:" leaving "/path/to/file.exe" and failing to match. This is fixed by no longer doing that.