### PR TITLE
Windows: add breakpoint stub for Windows ARM64

### DIFF
--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -35,6 +35,15 @@ static uint8_t const gDebugBreakCode[] = {
     0x00, 0x00, 0x00, 0x00  // 08: RtlExitUserThread address
 };
 static const int gRtlExitUserThreadOffset = 0x08;
+#elif defined(ARCH_ARM64)
+static uint8_t const gDebugBreakCode[] = {
+    0x00, 0x00, 0x3e, 0xd4, // 00: brk #0xf000
+    0x50, 0x00, 0x00, 0x58, // 04: ldr x16, #8
+    0x00, 0x02, 0x1f, 0xd6, // 08: br x16
+    0x00, 0x00, 0x00, 0x00, // 0B: RtlExitUserThread address
+    0x00, 0x00, 0x00, 0x00,
+};
+static const int gRtlExitUserThreadOffset = 0x0b;
 #elif defined(ARCH_X86)
 static uint8_t const gDebugBreakCode[] = {
     0xCC,                         // 00: int 3


### PR DESCRIPTION
This adds a breakpoint stub for Windows ARM64.  The following instruction sequence is used:

~~~
brk	#0xf000
ldr	x16, #8
br	x16
...
~~~

Windows ARM64 uses `brk #0xf000` as the debug interrupt sequence, and we follow the same pattern as the other architectures to simplify the writing of the stub.  The following would be shorter, but more complicated to emit:

~~~
brk	#0xf000
ldr	x16, :got:RtlExitUserThread
ldr	x16, [x16, :got_lo12:RtlExitUserThread]
br	x16
~~~