### PR TITLE
update the macos build to run on macos-13 instead of latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,10 @@ jobs:
             ${{ github.workspace }}/BinaryCache/ds2/ds2.exe
 
   macos:
-    runs-on: macos-latest
+    # The macos-latest runner image runs on an M1 ARM CPU which is not currently
+    # supported by ds2. Build on macos-13, which is x86_64-based, until Darwin
+    # on ARM support is implemented.
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The [macos-latest runner ](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources )is M1 ARM only, but ds2 doesn't support Darwin on ARM yet. Until that support is implemented, we can run on macos-13 to target x86 and keep the build green.