### PR TITLE
GHA: split the CMake invocation into line per option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,13 @@ jobs:
         run: choco install winflexbison3
 
       - name: Configure
-        run: cmake -B ${{ github.workspace }}/BinaryCache/ds2 -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake -D CMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022" -A ${{ matrix.arch }} -S ${{ github.workspace }}
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/ds2 `
+                -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake `
+                -D CMAKE_BUILD_TYPE=Release `
+                -G "Visual Studio 17 2022" `
+                -A ${{ matrix.arch }} `
+                -S ${{ github.workspace }}
       - name: Build
         run: cmake --build ${{ github.workspace }}/BinaryCache/ds2 --config Release
 
@@ -45,7 +51,7 @@ jobs:
         include:
           - { system: ucrt64, env: ucrt-x86_64 }
           - { system: clang64, env: clang-x86_64 }
-    
+
     steps:
       - uses: msys2/setup-msys2@v2
         with:
@@ -60,7 +66,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure
-        run: cmake -B $(cygpath -u '${{ github.workspace }}/BinaryCache/ds2') -C $(cygpath -u '${{ github.workspace }}/cmake/caches/GNUWarnings.cmake') -D CMAKE_BUILD_TYPE=Release -G Ninja -S $(cygpath -u '${{ github.workspace }}')
+        run: |
+          cmake -B $(cygpath -u '${{ github.workspace }}/BinaryCache/ds2')      \
+                -C $(cygpath -u '${{ github.workspace }}/cmake/caches/GNUWarnings.cmake') \
+                -D CMAKE_BUILD_TYPE=Release                                     \
+                -G Ninja                                                        \
+                -S $(cygpath -u '${{ github.workspace }}')
       - name: Build
         run: cmake --build $(cygpath -u '${{ github.workspace }}/BinaryCache/ds2') --config Release
 
@@ -81,7 +92,12 @@ jobs:
       - uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Configure
-        run: cmake -B ${{ github.workspace }}/BinaryCache/ds2 -C ${{ github.workspace }}/cmake/caches/ClangWarnings.cmake -D CMAKE_BUILD_TYPE=Release -G Ninja -S ${{ github.workspace }}
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/ds2                      \
+                -C ${{ github.workspace }}/cmake/caches/ClangWarnings.cmake     \
+                -D CMAKE_BUILD_TYPE=Release                                     \
+                -G Ninja                                                        \
+                -S ${{ github.workspace }}
       - name: Build
         run: cmake --build ${{ github.workspace }}/BinaryCache/ds2 --config Release
 
@@ -108,7 +124,16 @@ jobs:
           sudo apt-get install -qq --no-install-recommends bison flex gcc-multilib g++-multilib ninja-build
 
       - name: Configure
-        run: cmake -B ${{ github.workspace }}/BinaryCache/ds2 -C ${{ github.workspace }}/cmake/caches/GNUWarnings.cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_SYSTEM_NAME=Linux -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.processor }} -D CMAKE_C_FLAGS=${{ matrix.cflags }} -D CMAKE_CXX_FLAGS=${{ matrix.cxxflags }} -G Ninja -S ${{ github.workspace }}
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/ds2                      \
+                -C ${{ github.workspace }}/cmake/caches/GNUWarnings.cmake       \
+                -D CMAKE_BUILD_TYPE=Release                                     \
+                -D CMAKE_SYSTEM_NAME=Linux                                      \
+                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.processor }}               \
+                -D CMAKE_C_FLAGS=${{ matrix.cflags }}                           \
+                -D CMAKE_CXX_FLAGS=${{ matrix.cxxflags }}                       \
+                -G Ninja                                                        \
+                -S ${{ github.workspace }}
       - name: Build
         run: cmake --build ${{ github.workspace }}/BinaryCache/ds2 --config Releaase
 
@@ -136,7 +161,12 @@ jobs:
       # cmake finds the Android NDK from ANDROID_NDK in the environment, which
       # is pre-installed and configured in the Windows runner image.
       - name: Configure
-        run: cmake -B ${{ github.workspace }}/BinaryCache/ds2 -D CMAKE_BUILD_TYPE=Release -D CMAKE_SYSTEM_NAME=Android -D CMAKE_ANDROID_ARCH_ABI=${{ matrix.abi }} -G Ninja
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/ds2 `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_SYSTEM_NAME=Android `
+                -D CMAKE_ANDROID_ARCH_ABI=${{ matrix.abi }} `
+                -G Ninja
 
       - name: Build
         run: cmake --build ${{ github.workspace }}/BinaryCache/ds2 --config Release


### PR DESCRIPTION
This makes it easier to see at a glance what options are being passed to the cmake invocation during the configure phase.