### PR TITLE
[android] minimize llvm build to only what is required for running the lldb API tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,8 @@ jobs:
                 -G Ninja
       - name: Build lldb
         run: |
-          cmake --build ${{ github.workspace }}/llvm-project/build              \
+          cmake --build  ${{ github.workspace }}/llvm-project/build             \
+                --target tools/lldb/test/API/lldb-api-test-deps                 \
                 --config Release
 
       # Run a subset of the lldb API tests against ds2 runnint on an x86_64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
           cmake -B ${{ github.workspace }}/llvm-project/build                   \
                 -S ${{ github.workspace }}/llvm-project/llvm                    \
                 -D LLVM_ENABLE_PROJECTS='clang;lldb'                            \
-                -D LLVM_TARGETS_TO_BUILD="AArch64;ARM;RISCV;WebAssembly;X86"    \
+                -D LLVM_TARGETS_TO_BUILD="X86"                                  \
                 -D LLDB_ENABLE_PYTHON=On                                        \
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache                            \
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache                          \


### PR DESCRIPTION
Currently, building clang + lldb from llvm-project in the test work flow builds a total of **5270** targets. This change reduces the scope to only build targets needed to run the lldb tests from an x86 host against an Android emulator.

Specifically:

* Filtering `LLVM_TARGETS_TO_BUILD` to `X86` reduces total targets built to **4905**
* Explicitly building only the `tools/lldb/test/API/lldb-api-test-deps` target further reduces the total targets build to **4156**

This reduction should improve throughput and reduce disk usage of the `Build lldb` step in the test workflow.