### PR TITLE
[android] fix the sccache tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
-          key: ubuntu-${{ matrix.arch }}-llvm
+          key: llvm-${{ runner.os }}-${{ runner.arch }}
           variant: sccache
           append-timestamp: false
 


### PR DESCRIPTION
The sccache key for the llvm/lldb build should include the architecture of the host (runner) not the target.