### PR TITLE
allow RegsGen2 executable to be manually specified

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,34 @@ on:
   workflow_dispatch:
 
 jobs:
+  windows_tools:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: compnerd/gha-setup-vsdevenv@main
+
+      - name: Install Build Tools
+        run: choco install winflexbison3
+
+      - name: Configure
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/RegsGen2 `
+                -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake `
+                -G "Visual Studio 17 2022" `
+                -A x64 `
+                -S ${{ github.workspace }}/Tools/RegsGen2
+      - name: Build
+        run: cmake --build ${{ github.workspace }}/BinaryCache/RegsGen2 --config Release
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-regsgen2
+          path: |
+            ${{ github.workspace }}/BinaryCache/RegsGen2/Release/regsgen2.exe
+
   windows:
+    needs: [windows_tools]
     runs-on: windows-latest
 
     strategy:
@@ -20,13 +47,18 @@ jobs:
       - name: Install Build Tools
         run: choco install winflexbison3
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-regsgen2
+          path: ${{ github.workspace }}/BinaryCache/RegsGen2/Release
+
       - name: Configure
         run: |
           cmake -B ${{ github.workspace }}/BinaryCache/ds2 `
                 -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake `
-                -D CMAKE_BUILD_TYPE=Release `
                 -G "Visual Studio 17 2022" `
                 -A ${{ matrix.arch }} `
+                -D DS2_REGSGEN2=${{ github.workspace }}/BinaryCache/RegsGen2/Release/regsgen2.exe `
                 -S ${{ github.workspace }}
       - name: Build
         run: cmake --build ${{ github.workspace }}/BinaryCache/ds2 --config Release
@@ -39,6 +71,7 @@ jobs:
 
 
   mingw:
+    needs: [windows_tools]
     runs-on: windows-latest
 
     defaults:
@@ -65,12 +98,18 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-regsgen2
+          path: ${{ github.workspace }}/BinaryCache/RegsGen2/Release
+
       - name: Configure
         run: |
           cmake -B $(cygpath -u '${{ github.workspace }}/BinaryCache/ds2')      \
                 -C $(cygpath -u '${{ github.workspace }}/cmake/caches/GNUWarnings.cmake') \
                 -D CMAKE_BUILD_TYPE=Release                                     \
                 -G Ninja                                                        \
+                -D DS2_REGSGEN2=$(cygpath -u '${{ github.workspace }}/BinaryCache/RegsGen2/Release/regsgen2.exe') \
                 -S $(cygpath -u '${{ github.workspace }}')
       - name: Build
         run: cmake --build $(cygpath -u '${{ github.workspace }}/BinaryCache/ds2') --config Release
@@ -145,6 +184,7 @@ jobs:
 
   # Cross-compile for Android on a Windows host.
   android-windows-ndk:
+    needs: [windows_tools]
     runs-on: windows-latest
 
     strategy:
@@ -154,6 +194,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: seanmiddleditch/gha-setup-ninja@master
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-regsgen2
+          path: ${{ github.workspace }}/BinaryCache/RegsGen2/Release
 
       - name: Install Build Tools
         run: choco install winflexbison3
@@ -166,6 +210,7 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_SYSTEM_NAME=Android `
                 -D CMAKE_ANDROID_ARCH_ABI=${{ matrix.abi }} `
+                -D DS2_REGSGEN2=${{ github.workspace }}/BinaryCache/RegsGen2/Release/regsgen2.exe `
                 -G Ninja
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,37 +98,43 @@ else()
   message(SEND_ERROR "Unknown host architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
-if(CMAKE_HOST_SYSTEM STREQUAL Windows)
-  set(CMAKE_HOST_EXECUTABLE_SUFFIX .exe)
+if(DS2_REGSGEN2)
+  add_executable(RegsGen2::RegsGen2 IMPORTED)
+  set_target_properties(RegsGen2::RegsGen2 PROPERTIES
+	IMPORTED_LOCATION ${DS2_REGSGEN2})
 else()
-  set(CMAKE_HOST_EXECUTABLE_SUFFIX)
+  if(CMAKE_HOST_SYSTEM STREQUAL Windows)
+	set(CMAKE_HOST_EXECUTABLE_SUFFIX .exe)
+  else()
+	set(CMAKE_HOST_EXECUTABLE_SUFFIX)
+  endif()
+
+  get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if(GENERATOR_IS_MULTI_CONFIG)
+	set(RegsGen2_RELATIVE_PATH Release/regsgen2${CMAKE_HOST_EXECUTABLE_SUFFIX})
+  else()
+	set(RegsGen2_RELATIVE_PATH regsgen2${CMAKE_HOST_EXECUTABLE_SUFFIX})
+  endif()
+
+  include(ExternalProject)
+  ExternalProject_Add(RegsGen2
+	SOURCE_DIR ${PROJECT_SOURCE_DIR}/Tools/RegsGen2
+	BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/RegsGen2
+	CMAKE_ARGS
+	  -DCMAKE_BUILD_TYPE:STRING=Release
+	  -DCMAKE_SYSTEM_NAME:STRING=${CMAKE_HOST_SYSTEM_NAME}
+	  -DCMAKE_SYSTEM_PROCESSOR:STRING=${CMAKE_HOST_SYSTEM_PROCESSOR}
+	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
+	INSTALL_COMMAND ""
+	BUILD_BYPRODUCTS
+	  <BINARY_DIR>/${RegsGen2_RELATIVE_PATH})
+  ExternalProject_Get_Property(RegsGen2 BINARY_DIR)
+
+  add_executable(RegsGen2::RegsGen2 IMPORTED)
+  set_target_properties(RegsGen2::RegsGen2 PROPERTIES
+	IMPORTED_LOCATION ${BINARY_DIR}/${RegsGen2_RELATIVE_PATH})
+  add_dependencies(RegsGen2::RegsGen2 RegsGen2)
 endif()
-
-get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-if(GENERATOR_IS_MULTI_CONFIG)
-  set(RegsGen2_RELATIVE_PATH Release/regsgen2${CMAKE_HOST_EXECUTABLE_SUFFIX})
-else()
-  set(RegsGen2_RELATIVE_PATH regsgen2${CMAKE_HOST_EXECUTABLE_SUFFIX})
-endif()
-
-include(ExternalProject)
-ExternalProject_Add(RegsGen2
-  SOURCE_DIR ${PROJECT_SOURCE_DIR}/Tools/RegsGen2
-  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/RegsGen2
-  CMAKE_ARGS
-    -DCMAKE_BUILD_TYPE:STRING=Release
-    -DCMAKE_SYSTEM_NAME:STRING=${CMAKE_HOST_SYSTEM_NAME}
-    -DCMAKE_SYSTEM_PROCESSOR:STRING=${CMAKE_HOST_SYSTEM_PROCESSOR}
-  BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
-  INSTALL_COMMAND ""
-  BUILD_BYPRODUCTS
-    <BINARY_DIR>/${RegsGen2_RELATIVE_PATH})
-ExternalProject_Get_Property(RegsGen2 BINARY_DIR)
-
-add_executable(RegsGen2::RegsGen2 IMPORTED)
-set_target_properties(RegsGen2::RegsGen2 PROPERTIES
-  IMPORTED_LOCATION ${BINARY_DIR}/${RegsGen2_RELATIVE_PATH})
-add_dependencies(RegsGen2::RegsGen2 RegsGen2)
 
 # Generate different pointer size RISC-V definitions.
 # FIXME(compnerd) this assumes all targets are RISCVnnnG, which may not be true.


### PR DESCRIPTION
Adds a new `DS2_REGSGEN2` CMake variable to manually specify the RegsGen2 executable invoked during the DS2 build. If the variable is not specified it falls-back to the previous behavior of building it as an external project.

Update GitHub builds for Windows, MinGW, and Android to pre-build the RegsGen2 executable in a separate `windows_tools` step which properly uses the VS toolchain.