### PR TITLE
[gha] nightly build/test/tag workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   windows_tools:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,37 @@
+name: nightly
+
+on:
+  # Run once daily at 8:45 PM.
+  schedule:
+    - cron: "45 20 * * */1"
+
+  # Allow manually-triggered runs.
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  test:
+    uses: ./.github/workflows/test.yml
+
+  # Generate a nightly tag if build and test jobs succeed.
+  tag:
+    needs: [build, test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get today's date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Create nightly tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/nightly-${{ steps.date.outputs.date }}",
+              sha: context.sha
+            })

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,9 @@
 name: nightly
 
 on:
-  # Run once daily at 8:45 PM.
+  # Run once daily at 4:45 AM UTC.
   schedule:
-    - cron: "45 20 * * */1"
+    - cron: "45 04 * * */1"
 
   # Allow manually-triggered runs.
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   workflow_dispatch:
-
+  workflow_call:
 
 jobs:
   # Test the Android ds2 binary on an emulator.


### PR DESCRIPTION
Adds a new GHA workflow to run the existing build and test workflows every night at 8:45 PM.
On success, create a new tag with the format "nightly-YYYY-MM-DD".

### Test Plan
Manually invoked the workflow [here](https://github.com/andrurogerz/ds2/actions/runs/10188630108).

Validated scheduling of the full workflow on my fork [here](https://github.com/andrurogerz/ds2/actions/runs/10205543363). The [tag](https://github.com/andrurogerz/ds2/releases/tag/nightly-2024-08-01) was created successfully. 