### PR TITLE
[gha] cache Android NDK and emulator in test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,7 +340,8 @@ jobs:
       matrix:
         # We don't currently have a good way to run arm64 Android emulator on
         # the available GitHub test runners.
-        processor: ['x86_64']
+        include:
+          - { processor: x86_64, api-level: 28 }
 
     steps:
       # Free up some disk space by removing some things we don't use. Without
@@ -426,12 +427,34 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.processor }}-${{ matrix.api-level }}
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: ${{ matrix.processor }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
       - name: Run lldb tests against ds2 on Android emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 28
+          api-level: ${{ matrix.api-level }}
           arch: ${{ matrix.processor }}
-          emulator-options: -no-window -noaudio -no-boot-anim
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
           script: |
             $ANDROID_SDK_ROOT/platform-tools/adb forward tcp:5432 tcp:5432
             $ANDROID_SDK_ROOT/platform-tools/adb push ${{ github.workspace }}/BinaryCache/ds2/ds2 /data/local/tmp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,6 +418,7 @@ jobs:
           # test binaries against. The lldb test framework will need to be
           # modified to run with a more recent NDK.
           ndk-version: r21e
+          local-cache: true
 
       - name: Enable KVM
         run: |


### PR DESCRIPTION
Use GitHub caching to speed up the test-android test job, which is the long-pole in the ds2 Build and Test workflow. It will save us a couple of minutes per run.

Uses caching in two places:
1. Cache the NDK. Since the same one is installed every run, it saves some time to keep it in the cache rather than download from Google.
2. Cache emulator image, device, and boot state. Caching this way is suggested in the [documentation](ReactiveCircus/android-emulator-runner) for ReactiveCircus/android-emulator-runner.

## Test Plan
Ran the job twice and confirmed caches are created on the [first run](https://github.com/andrurogerz/ds2/actions/runs/10378830372/job/28736441339) and are reused on the [second run](https://github.com/andrurogerz/ds2/actions/runs/10379453910/job/28737800544).