### PR TITLE
[android] use procfs to check pid validity

### DIFF
--- a/Sources/Target/Linux/Process.cpp
+++ b/Sources/Target/Linux/Process.cpp
@@ -364,7 +364,15 @@ bool Process::isAlive() const {
     break;
   }
 
-  return super::isAlive();
+  if (_pid <= 0)
+    return false;
+
+  auto dir = ProcFS::OpenDIR(_pid, "");
+  if (dir == nullptr)
+    return false;
+
+  closedir(dir);
+  return true;
 }
 
 ds2::Host::Linux::PTrace &Process::ptrace() const {


### PR DESCRIPTION
### Summary
The POSIX implementation of `Process::isAlive()` relies on successfully calling `kill(pid, 0)` to validate the target process' PID. This call fails with `EPERM` when ds2 is running in an Android app sandbox (at least newer Android versions).

### Overview
Fix the issue by instead checking that `/proc/PID` exists. Perform this check only in the Linux override of `Process::isAlive()` since using procfs is not portable. There is no reason to scope the change to be Android-only, though, since it will work on any Linux system.

### Background
Since it doesn't show up here, the implementation of `super::isAlive()` that this PR replaces is [here](https://github.com/compnerd/ds2/blob/main/Sources/Target/POSIX/Process.cpp#L73).

It is worth noting that any solution to validate a PID is best-effort and is inherently racy. We could technically eliminate the check entirely and ds2 will still work-- it just won't fail as fast when trying to attach to an invalid PID.

### Validation
Connect lldb to a ds2 instance running in the sandbox of an Android app on a connected Android device or emulator. The Android app must also have `android.permission.INTERNET` for ds2 to open a socket.

1. Copy ds2 to the device and into the app sandbox:
```
adb push build\ds2 /data/local/tmp
adb shell chmod +x /data/local/tmp
adb forward tcp:6543 tcp:6543
run-as com.example.DemoApp cp /data/local/tmp/ds2/ds2 ./ds2
run-as com.example.DemoApp ./ds2 platform --listen localhost:6543 --server -D -d 
```
2.  Launch and connect lldb to the running ds2 instance:
```
(lldb) platform select remote-android
(lldb) platform connect connect://localhost:6543
```
3. Launch the Android app, get its PID, and attach lldb
```
am start -n com.example.DemoApp/com.package.DemoApp.DefaultActivity
```
4. Once lldb attaches, continue execution with `(lldb) c`.

#### Expected Behavior
lldb should remain connected to ds2

#### Actual Behavior
Without this change, it drops the debugger connection