### PR TITLE
[freebsd] fix the freebsd build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "X86" OR
       CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
   set(DS2_ARCHITECTURE X86)
 elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "X64" OR
-      CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64|x86_64")
+      CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|AMD64|x86_64")
   set(DS2_ARCHITECTURE X86_64)
 elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "RISCV32|RISCV64|RISCV128" OR
        CMAKE_SYSTEM_PROCESSOR MATCHES "riscv32|riscv64|riscv128")
@@ -140,25 +140,29 @@ else()
 endif()
 
 foreach(ARCH ARM ARM64 RISCV32 RISCV64 RISCV128 X86 X86_64)
+  set(ArchHeadersDir ${CMAKE_CURRENT_BINARY_DIR}/Headers/DebugServer2/Architecture/${ARCH})
+  file(MAKE_DIRECTORY ${ArchHeadersDir})
   add_custom_command(OUTPUT
-      ${CMAKE_CURRENT_BINARY_DIR}/Headers/DebugServer2/Architecture/${ARCH}/RegistersDescriptors.h
+      ${ArchHeadersDir}/RegistersDescriptors.h
     COMMAND
       $<TARGET_FILE:RegsGen2::RegsGen2>
         -a ${RegsGenOS}
         -I DebugServer2/Architecture/RegisterLayout.h
-        -h -o ${CMAKE_CURRENT_BINARY_DIR}/Headers/DebugServer2/Architecture/${ARCH}/RegistersDescriptors.h
+	-h -o ${ArchHeadersDir}/RegistersDescriptors.h
         -f "${PROJECT_SOURCE_DIR}/Definitions/${ARCH}.json"
     DEPENDS
       Definitions/${ARCH}.json
       RegsGen2::RegsGen2)
 
+  set(ArchSourcesDir ${CMAKE_CURRENT_BINARY_DIR}/Sources/Architecture/${ARCH})
+  file(MAKE_DIRECTORY ${ArchSourcesDir})
   add_custom_command(OUTPUT
-      ${CMAKE_CURRENT_BINARY_DIR}/Sources/Architecture/${ARCH}/RegistersDescriptors.cpp
+      ${ArchSourcesDir}/RegistersDescriptors.cpp
     COMMAND
       $<TARGET_FILE:RegsGen2::RegsGen2>
         -a ${RegsGenOS}
         -I DebugServer2/Architecture/${ARCH}/RegistersDescriptors.h
-        -c -o ${CMAKE_CURRENT_BINARY_DIR}/Sources/Architecture/${ARCH}/RegistersDescriptors.cpp
+	-c -o ${ArchSourcesDir}/RegistersDescriptors.cpp
         -f "${PROJECT_SOURCE_DIR}/Definitions/${ARCH}.json"
     DEPENDS
       Definitions/${ARCH}.json

--- a/Sources/Utils/POSIX/FaultHandler.cpp
+++ b/Sources/Utils/POSIX/FaultHandler.cpp
@@ -31,7 +31,7 @@ private:
   }
 
   void installCatcher() {
-#if defined(__APPLE__)
+#if defined(__APPLE__) or defined(__FreeBSD__)
     long sz = SIGSTKSZ;
 #elif defined(__ANDROID__)
     long sz = MINSIGSTKSZ;

--- a/Sources/Utils/POSIX/FaultHandler.cpp
+++ b/Sources/Utils/POSIX/FaultHandler.cpp
@@ -31,7 +31,7 @@ private:
   }
 
   void installCatcher() {
-#if defined(__APPLE__) or defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
     long sz = SIGSTKSZ;
 #elif defined(__ANDROID__)
     long sz = MINSIGSTKSZ;

--- a/Tools/JSObjects/CMakeLists.txt
+++ b/Tools/JSObjects/CMakeLists.txt
@@ -49,6 +49,11 @@ target_include_directories(jsobjects PRIVATE
     ${JSObjects_SOURCE_DIR}/Sources/libjson
     ${JSObjects_BINARY_DIR})
 
+if("${BSD}" STREQUAL "FreeBSD")
+  target_compile_definitions(jsobjects PRIVATE
+    _XOPEN_SOURCE=600)
+endif()
+
 if((CMAKE_C_COMPILER_ID MATCHES "GNU" AND
     CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.6) OR
    ((CMAKE_C_COMPILER_ID MATCHES "Clang" AND


### PR DESCRIPTION
I wanted to verify some Linux-specific changes don't break other platforms and found that ds2 doesn't currently build on FreeBSD 14.0. These patches address the issues encountered.

The most noteworthy change is the addition of `file(MAKE_DIRECTORY)` calls to the `RegsGen2` steps. This step was failing on FreeBSD because the directories did not already exist. Not sure why it succeeds on other platforms, but the `MAKE_DIRECTORY` addition should be harmless when not needed.

### Validation
Built on VM running 14.0-RELEASE-p10.
Launched ds2 on FreeBSD in platform mode, verified lldb can connect.