### PR TITLE
[android] implement support for `qModuleInfo` packet

### DIFF
--- a/Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h
@@ -95,6 +95,9 @@ protected: // Debugging Session
   ErrorCode onQuerySharedLibraryInfo(Session &session, std::string const &path,
                                      std::string const &triple,
                                      SharedLibraryInfo &info) const override;
+  ErrorCode onQueryModuleInfo(Session &session, std::string &path,
+                              std::string &triple,
+                              ModuleInfo &info) const override;
 
   ErrorCode onRestart(Session &session, ProcessId pid) override;
   ErrorCode onInterrupt(Session &session) override;

--- a/Headers/DebugServer2/GDBRemote/PlatformSessionImpl.h
+++ b/Headers/DebugServer2/GDBRemote/PlatformSessionImpl.h
@@ -43,6 +43,10 @@ protected:
   ErrorCode onQueryGroupName(Session &session, GroupId const &gid,
                              std::string &name) const override;
 
+  ErrorCode onQueryModuleInfo(Session &session, std::string &path,
+                              std::string &triple,
+                              ModuleInfo &info) const override;
+
 protected:
   ErrorCode onLaunchDebugServer(Session &session, std::string const &host,
                                 uint16_t &port, ProcessId &pid) override;

--- a/Headers/DebugServer2/GDBRemote/SessionDelegate.h
+++ b/Headers/DebugServer2/GDBRemote/SessionDelegate.h
@@ -103,6 +103,9 @@ protected: // Debugging Session
                                              std::string const &path,
                                              std::string const &triple,
                                              SharedLibraryInfo &info) const = 0;
+  virtual ErrorCode onQueryModuleInfo(Session &session, std::string &path,
+                                      std::string &triple,
+                                      ModuleInfo &info) const = 0;
 
   virtual ErrorCode onRestart(Session &session, ProcessId pid) = 0;
   virtual ErrorCode onInterrupt(Session &session) = 0;

--- a/Headers/DebugServer2/GDBRemote/Types.h
+++ b/Headers/DebugServer2/GDBRemote/Types.h
@@ -31,6 +31,10 @@ struct MemoryRegionInfo : public ds2::MemoryRegionInfo {
   std::string encode() const;
 };
 
+struct ModuleInfo : public ds2::ModuleInfo {
+  std::string encode() const;
+};
+
 struct StopInfo : public ds2::StopInfo {
 public:
   // Allow copying and constructing from a ds2::StopInfo directly.

--- a/Headers/DebugServer2/Host/File.h
+++ b/Headers/DebugServer2/Host/File.h
@@ -61,6 +61,9 @@ public:
 public:
   static ErrorCode createDirectory(std::string const &path, uint32_t flags);
 
+public:
+  static ErrorCode fileSize(std::string const &path, uint64_t &size);
+
 protected:
   int _fd;
   ErrorCode _lastError;

--- a/Headers/DebugServer2/Host/Platform.h
+++ b/Headers/DebugServer2/Host/Platform.h
@@ -77,6 +77,9 @@ public:
 
 public:
   static std::string GetThreadName(ProcessId pid, ThreadId tid);
+
+public:
+  static bool GetExecutableFileBuildID(std::string const &path, ByteVector &buildId);
 };
 } // namespace Host
 } // namespace ds2

--- a/Headers/DebugServer2/Support/POSIX/ELFSupport.h
+++ b/Headers/DebugServer2/Support/POSIX/ELFSupport.h
@@ -25,6 +25,15 @@ public:
 public:
   static bool MachineTypeToCPUType(uint32_t machineType, bool is64Bit,
                                    CPUType &type, CPUSubType &subType);
+  static bool GetELFFileBuildID(std::string const &path, ByteVector &buildID);
+private:
+  template <class T_EHDR, class T_SHDR, class T_NHDR>
+  static bool ReadBuildID(int fd, const T_EHDR &ehdr, T_SHDR &shdr,
+                          T_NHDR &nhdr, ByteVector &id);
+
+  template <class T_EHDR, class T_SHDR>
+  static bool ReadSectionHeader(int fd, const T_EHDR &ehdr, T_SHDR &shdr,
+                                size_t idx);
 };
 } // namespace Support
 } // namespace ds2

--- a/Headers/DebugServer2/Support/POSIX/ELFSupport.h
+++ b/Headers/DebugServer2/Support/POSIX/ELFSupport.h
@@ -27,12 +27,12 @@ public:
                                    CPUType &type, CPUSubType &subType);
   static bool GetELFFileBuildID(std::string const &path, ByteVector &buildID);
 private:
-  template <class T_EHDR, class T_SHDR, class T_NHDR>
-  static bool ReadBuildID(int fd, const T_EHDR &ehdr, T_SHDR &shdr,
-                          T_NHDR &nhdr, ByteVector &id);
+  template <typename ELFHeader, typename SectionHeader, typename NotesHeader>
+  static bool ReadBuildID(int fd, const ELFHeader &ehdr, SectionHeader &shdr,
+                          NotesHeader &nhdr, ByteVector &id);
 
-  template <class T_EHDR, class T_SHDR>
-  static bool ReadSectionHeader(int fd, const T_EHDR &ehdr, T_SHDR &shdr,
+  template <typename ELFHeader, typename SectionHeader>
+  static bool ReadSectionHeader(int fd, const ELFHeader &ehdr, SectionHeader &shdr,
                                 size_t idx);
 };
 } // namespace Support

--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -410,4 +410,13 @@ struct MappedFileInfo {
   uint64_t baseAddress;
   uint64_t size;
 };
+
+struct ModuleInfo {
+  std::string uuid;
+  std::string triple;
+  std::string file_path;
+  uint64_t file_offset;
+  uint64_t file_size;
+};
+
 } // namespace ds2

--- a/Sources/GDBRemote/DummySessionDelegateImpl.cpp
+++ b/Sources/GDBRemote/DummySessionDelegateImpl.cpp
@@ -159,6 +159,9 @@ DUMMY_IMPL_EMPTY_CONST(onQuerySharedLibraryInfo, Session &,
                        std::string const &path, std::string const &triple,
                        SharedLibraryInfo &info)
 
+DUMMY_IMPL_EMPTY_CONST(onQueryModuleInfo, Session &, std::string &path,
+                       std::string &triple, ModuleInfo &info)
+
 DUMMY_IMPL_EMPTY(onRestart, Session &, ProcessId)
 
 DUMMY_IMPL_EMPTY(onInterrupt, Session &)

--- a/Sources/GDBRemote/PlatformSessionImpl.cpp
+++ b/Sources/GDBRemote/PlatformSessionImpl.cpp
@@ -16,6 +16,7 @@
 
 #include <sstream>
 
+using ds2::Host::File;
 using ds2::Host::Platform;
 using ds2::Host::ProcessSpawner;
 
@@ -93,6 +94,31 @@ ErrorCode PlatformSessionImplBase::onQueryGroupName(Session &,
     return kErrorNotFound;
   else
     return kSuccess;
+}
+
+ErrorCode PlatformSessionImplBase::onQueryModuleInfo(Session &session,
+                                                     std::string &path,
+                                                     std::string &triple,
+                                                     ModuleInfo &info) const {
+  ByteVector buildId;
+  if (!Platform::GetExecutableFileBuildID(path, buildId))
+    return kErrorUnknown;
+
+  // send the uuid as a hex-encoded, upper-case string
+  std::ostringstream ss;
+  for(const auto b : buildId)
+    ss << std::uppercase << std::hex << std::setfill('0') << std::setw(2) << int(b);
+
+  auto error = File::fileSize(path, info.file_size);
+  if (error != kSuccess)
+    return error;
+
+  info.uuid = ss.str();
+  info.triple = triple;
+  info.file_path = path;
+  info.file_offset = 0;
+
+  return kSuccess;
 }
 
 ErrorCode PlatformSessionImplBase::onLaunchDebugServer(Session &session,

--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -1843,12 +1843,11 @@ void Session::Handle_qModuleInfo(ProtocolInterpreter::Handler const &,
   size_t semicolon = args.find(';');
   std::string path(HexToString(args.substr(0, semicolon)));
   std::string triple(HexToString(args.substr(semicolon + 1)));
-  SharedLibraryInfo info;
+  ModuleInfo info;
 
-  CHK_SEND(_delegate->onQuerySharedLibraryInfo(*this, path, triple, info));
+  CHK_SEND(_delegate->onQueryModuleInfo(*this, path, triple, info));
 
-  // FIXME: send the actual response.
-  sendOK();
+  send(info.encode());
 }
 
 //

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -844,5 +844,15 @@ std::string ProgramResult::encode() const {
      << ',' << Escape(output);
   return ss.str();
 }
+
+std::string ModuleInfo::encode() const {
+  std::ostringstream ss;
+  ss << "uuid:" << ToHex(uuid) << ";";
+  ss << "triple:" << ToHex(triple) << ";";
+  ss << "file_path:" << ToHex(file_path) << ";";
+  ss << "file_offset:" << HEX(16) << file_offset << ";";
+  ss << "file_size:" << HEX(16) << file_size << ";";
+  return ss.str();
+}
 } // namespace GDBRemote
 } // namespace ds2

--- a/Sources/Host/Darwin/Platform.cpp
+++ b/Sources/Host/Darwin/Platform.cpp
@@ -140,5 +140,10 @@ void Platform::EnumerateProcesses(
 std::string Platform::GetThreadName(ProcessId pid, ThreadId tid) {
   return Host::Darwin::LibProc::GetThreadName(ProcessThreadId(pid, tid));
 }
+
+bool Platform::GetExecutableFileBuildID(std::string const &path, ByteVector &buildId) {
+  // TODO(andrurogerz): implement for Mach-O files
+  return false;
+}
 } // namespace Host
 } // namespace ds2

--- a/Sources/Host/FreeBSD/Platform.cpp
+++ b/Sources/Host/FreeBSD/Platform.cpp
@@ -10,6 +10,7 @@
 
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Host/FreeBSD/ProcStat.h"
+#include "DebugServer2/Support/POSIX/ELFSupport.h"
 
 #include <sys/utsname.h>
 
@@ -63,6 +64,10 @@ void Platform::EnumerateProcesses(
 
 std::string Platform::GetThreadName(ProcessId pid, ThreadId tid) {
   return Host::FreeBSD::ProcStat::GetThreadName(pid, tid);
+}
+
+bool Platform::GetExecutableFileBuildID(std::string const &path, ByteVector &buildId) {
+  return Support::ELFSupport::GetELFFileBuildID(path, buildId);
 }
 } // namespace Host
 } // namespace ds2

--- a/Sources/Host/Linux/Platform.cpp
+++ b/Sources/Host/Linux/Platform.cpp
@@ -10,6 +10,7 @@
 
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Host/Linux/ProcFS.h"
+#include "DebugServer2/Support/POSIX/ELFSupport.h"
 #include "DebugServer2/Utils/String.h"
 
 #include <sys/utsname.h>
@@ -117,6 +118,10 @@ void Platform::EnumerateProcesses(
 
 std::string Platform::GetThreadName(ProcessId pid, ThreadId tid) {
   return Host::Linux::ProcFS::GetThreadName(pid, tid);
+}
+
+bool Platform::GetExecutableFileBuildID(std::string const &path, ByteVector &buildId) {
+  return Support::ELFSupport::GetELFFileBuildID(path, buildId);
 }
 } // namespace Host
 } // namespace ds2

--- a/Sources/Host/POSIX/File.cpp
+++ b/Sources/Host/POSIX/File.cpp
@@ -157,8 +157,7 @@ ErrorCode File::createDirectory(std::string const &path, uint32_t flags) {
 
 ErrorCode File::fileSize(std::string const &path, uint64_t &size) {
   struct stat stbuf;
-  const auto result = stat(path.c_str(), &stbuf);
-  if (result < 0)
+  if (stat(path.c_str(), &stbuf) < 0)
     return Platform::TranslateError();
 
   size = static_cast<uint64_t>(stbuf.st_size);

--- a/Sources/Host/POSIX/File.cpp
+++ b/Sources/Host/POSIX/File.cpp
@@ -154,5 +154,15 @@ ErrorCode File::createDirectory(std::string const &path, uint32_t flags) {
 
   return kSuccess;
 }
+
+ErrorCode File::fileSize(std::string const &path, uint64_t &size) {
+  struct stat stbuf;
+  const auto result = stat(path.c_str(), &stbuf);
+  if (result < 0)
+    return Platform::TranslateError();
+
+  size = static_cast<uint64_t>(stbuf.st_size);
+  return kSuccess;
+}
 } // namespace Host
 } // namespace ds2

--- a/Sources/Host/Windows/File.cpp
+++ b/Sources/Host/Windows/File.cpp
@@ -38,5 +38,9 @@ ErrorCode File::unlink(std::string const &path) { return kErrorUnsupported; }
 ErrorCode File::createDirectory(std::string const &path, uint32_t flags) {
   return kErrorUnsupported;
 }
+
+ErrorCode File::fileSize(std::string const &path, uint64_t &size) {
+  return kErrorUnsupported;
+}
 } // namespace Host
 } // namespace ds2

--- a/Sources/Host/Windows/Platform.cpp
+++ b/Sources/Host/Windows/Platform.cpp
@@ -384,5 +384,10 @@ std::string Platform::GetThreadName(ProcessId pid, ThreadId tid) {
   // might end up using something similar for the inferior.
   return "";
 }
+
+bool Platform::GetExecutableFileBuildID(std::string const &path, ByteVector &buildId) {
+  // TODO(andrurogerz): implement for Windows executable files.
+  return false;
+}
 } // namespace Host
 } // namespace ds2

--- a/Sources/Support/POSIX/ELFSupport.cpp
+++ b/Sources/Support/POSIX/ELFSupport.cpp
@@ -88,11 +88,12 @@ bool ELFSupport::GetELFFileBuildID(std::string const &path, ByteVector &buildId)
 
   bool result = false;
   switch (e32hdr.e_ident[EI_CLASS]) {
-    case ELFCLASS32:
-      Elf32_Shdr s32hdr;
-      Elf32_Nhdr n32hdr;
-      result = ReadBuildID(fd, e32hdr, s32hdr, n32hdr, buildId);
+    case ELFCLASS32: {
+      Elf32_Shdr shdr;
+      Elf32_Nhdr nhdr;
+      result = ReadBuildID(fd, e32hdr, shdr, nhdr, buildId);
       break;
+    }
 
     case ELFCLASS64:
       Elf64_Ehdr e64hdr;
@@ -118,9 +119,9 @@ bool ELFSupport::GetELFFileBuildID(std::string const &path, ByteVector &buildId)
   return result;
 }
 
-template <class T_EHDR, class T_SHDR, class T_NHDR>
-bool ELFSupport::ReadBuildID(int fd, const T_EHDR &ehdr, T_SHDR &shdr,
-                             T_NHDR &nhdr, ByteVector &id) {
+template <typename ELFHeader, typename SectionHeader, typename NotesHeader>
+bool ELFSupport::ReadBuildID(int fd, const ELFHeader &ehdr, SectionHeader &shdr,
+                             NotesHeader &nhdr, ByteVector &id) {
     // Build ID is found in a note section with note type NT_GNU_BUILD_ID.
     // The section is typically named .note.gnu.build-id.
     for (size_t i = 0; i < ehdr.e_shnum; i++) {
@@ -147,8 +148,8 @@ bool ELFSupport::ReadBuildID(int fd, const T_EHDR &ehdr, T_SHDR &shdr,
     return false;
 }
 
-template <class T_EHDR, class T_SHDR>
-bool ELFSupport::ReadSectionHeader(int fd, const T_EHDR &ehdr, T_SHDR &shdr,
+template <typename ELFHeader, typename SectionHeader>
+bool ELFSupport::ReadSectionHeader(int fd, const ELFHeader &ehdr, SectionHeader &shdr,
                                    size_t idx) {
   if (idx >= ehdr.e_shnum)
     return false;


### PR DESCRIPTION
## Purpose
Properly respond to the GDB `qModuleInfo` packet, defined [here](https://lldb.llvm.org/resources/lldbgdbremote.html#qmoduleinfo-module-path-arch-triple), in the DS2 platform session.

## Overview
* Implement basic support to parse the build ID out of an ELF executable file
* Define a new `GetExecutableFileBuildID` method in the `Host::Platform` interface and implement a Linux and FreeBSD version based on the new ELF support to fetch build ID
* Define a new `fileSize` method in the `Host::File` interface and implement a POSIX version based on `stat`
* Define a new `onQueryModuleInfo` method in the `Session` interface and implement it in the platform session using the new file size and executable file build ID implementations

If deemed important, we can eventually implement [`jModulesInfo`](https://lldb.llvm.org/resources/lldbgdbremote.html#jmodulesinfo-file-triple) using the bulk of this implementation.

## Problem Details
Though `qModuleInfo` is documented as optional for lldb support, I have found it must be implemented on Android in order to properly resolve symbols of on-device executable files.



## Validation
On an aarch64 Android device and x86_64 Android emulator, attach lldb to a ds2 instance running in the app sandbox. Verify that images are loaded with `(lldb) image list`.

Verify Swift symbols from an Android test app can be looked-up in lldb:
```
(lldb) image lookup --name getSwiftGreeting
2 matches found in C:\Users\user\.lldb\module_cache\remote-android\.cache\2749C9AB-7810-6105\libSwiftMainActivity.so:
        Address: libSwiftMainActivity.so[0x0000000000006f40] (libSwiftMainActivity.so.PT_LOAD[1]..text + 864)
        Summary: libSwiftMainActivity.so`Java_com_thebrowsercompany_SwiftSupportTestApp_MainActivity_getSwiftGreeting at <compiler-generated>
        Address: libSwiftMainActivity.so[0x0000000000006f50] (libSwiftMainActivity.so.PT_LOAD[1]..text + 880)
        Summary: libSwiftMainActivity.so`SwiftMainActivity.getSwiftGreeting(Swift.UnsafeMutablePointer<Swift.Optional<Swift.UnsafePointer<__C.JNINativeInterface>>>, Swift.UnsafeMutableRawPointer) -> Swift.Optional<Swift.UnsafeMutableRawPointer> at MainActivity.swift:8
(lldb)
```

Build and execute on an AMD64 FreeBSD 14.0 host to verify the build is not broken.
