### PR TITLE
[android]  print backtraces on ds2 crashes/errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,12 @@ endif()
 add_subdirectory(Tools/JSObjects "${CMAKE_CURRENT_BINARY_DIR}/JSObjects")
 target_link_libraries(ds2 PRIVATE jsobjects)
 
+if(APPLE OR ANDROID OR LINUX)
+  # include all symbols on debug builds to print a readable backtrace on ds2 crash
+  target_link_options(ds2 PRIVATE
+    $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-rdynamic>)
+endif()
+
 if(ANDROID)
   target_link_libraries(ds2 PRIVATE log)
 elseif(LINUX AND NOT TIZEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,12 +410,6 @@ endif()
 add_subdirectory(Tools/JSObjects "${CMAKE_CURRENT_BINARY_DIR}/JSObjects")
 target_link_libraries(ds2 PRIVATE jsobjects)
 
-if(APPLE OR ANDROID OR LINUX)
-  # include all symbols on debug builds to print a readable backtrace on ds2 crash
-  target_link_options(ds2 PRIVATE
-    $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-rdynamic>)
-endif()
-
 if(ANDROID)
   target_link_libraries(ds2 PRIVATE log)
 elseif(LINUX AND NOT TIZEN)

--- a/Sources/Utils/Backtrace.cpp
+++ b/Sources/Utils/Backtrace.cpp
@@ -50,7 +50,7 @@ static _Unwind_Reason_Code UnwindTrace(struct _Unwind_Context* context,
 }
 
 // An approximation of glibc's backtrace using _Unwind_Backtrace
-static int backtrace(void *stack_buffer[], int stack_size) {
+static int UnwindBacktrace(void *stack_buffer[], int stack_size) {
   unwind_state state = {
     .buffer_cursor = stack_buffer,
     .buffer_end = stack_buffer + stack_size,
@@ -58,6 +58,11 @@ static int backtrace(void *stack_buffer[], int stack_size) {
 
   _Unwind_Backtrace(UnwindTrace, &state);
   return state.buffer_cursor - stack_buffer;
+}
+#else
+// Forward to glibc's backtrace
+static int UnwindBacktrace(void *stack_buffer[], int stack_size) {
+  return ::backtrace(stack_buffer, stack_size);
 }
 #endif
 
@@ -69,7 +74,7 @@ static void PrintBacktraceEntrySimple(void *address) {
 void PrintBacktrace() {
   static const int kStackSize = 100;
   static void *stack[kStackSize];
-  int stackEntries = backtrace(stack, kStackSize);
+  int stackEntries = UnwindBacktrace(stack, kStackSize);
 
   for (int i = 0; i < stackEntries; ++i) {
     Dl_info info;

--- a/Sources/Utils/Backtrace.cpp
+++ b/Sources/Utils/Backtrace.cpp
@@ -59,7 +59,7 @@ static int UnwindBacktrace(void *stack_buffer[], int stack_size) {
   _Unwind_Backtrace(UnwindTrace, &state);
   return state.buffer_cursor - stack_buffer;
 }
-#else
+#elif defined(OS_DARWIN) || (defined(__GLIBC__) && !defined(PLATFORM_TIZEN))
 // Forward to glibc's backtrace
 static int UnwindBacktrace(void *stack_buffer[], int stack_size) {
   return ::backtrace(stack_buffer, stack_size);

--- a/Sources/Utils/Backtrace.cpp
+++ b/Sources/Utils/Backtrace.cpp
@@ -94,10 +94,12 @@ void PrintBacktrace() {
       name = "<unknown>";
     }
 
-    DS2LOG(Error, "%" PRI_PTR " %s+%#" PRIxPTR " (%s)", PRI_PTR_CAST(stack[i]),
+    DS2LOG(Error, "%" PRI_PTR " %s+%#" PRIxPTR " (%s+%#" PRIxPTR ")",
+           PRI_PTR_CAST(stack[i]),
            name,
            static_cast<char *>(stack[i]) - static_cast<char *>(info.dli_saddr),
-           info.dli_fname);
+           info.dli_fname,
+           static_cast<char *>(stack[i]) - static_cast<char *>(info.dli_fbase));
 
     ::free(demangled);
   }


### PR DESCRIPTION
## Purpose
Add support to print ds2 backtraces on Android from the signal handler to diagnose crashes and fatal errors in DS2 itself.

## Overview
* Reuse the existing backtrace plumbing and implement only the glibc `backtrace` functionality missing on Android
* Log  the module-relative address of each stack frame in addition to the existing information.

## Problem Details
No backtraces are currently logged when DS2 crashes or encounters a fatal error on Android because `ds2::utils::PrintBacktrace` function is stubbed-out on platforms without glibc. Instead of glibc, Android provides  `libunwind` in the NDK exposed in the `unwind.h` header.

## Validation
Manually verified mostly complete backtraces are emitted from signal handler context during a ds2 crash on a Debug. Verified with ds2 built for 4 Android ABIs. x86, x86_64, armeabi-v7a, and arm64-v8a.

Example fatal error log (from x86_64):
```
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00005f03b2caed35 <unknown>+0x5f03b2caed35 (/data/local/tmp/ds2+0xa7d35)
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00005f03b2cafb88 <unknown>+0x5f03b2cafb88 (/data/local/tmp/ds2+0xa8b88)
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00005f03b2cc144f <unknown>+0x5f03b2cc144f (/data/local/tmp/ds2+0xba44f)
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00005f03b2c785ed <unknown>+0x5f03b2c785ed (/data/local/tmp/ds2+0x715ed)
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00005f03b2c9c59f <unknown>+0x5f03b2c9c59f (/data/local/tmp/ds2+0x9559f)
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00005f03b2c84bfe <unknown>+0x5f03b2c84bfe (/data/local/tmp/ds2+0x7dbfe)
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00005f03b2c847d2 <unknown>+0x5f03b2c847d2 (/data/local/tmp/ds2+0x7d7d2)
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00005f03b2ca2dc8 <unknown>+0x5f03b2ca2dc8 (/data/local/tmp/ds2+0x9bdc8)
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00005f03b2c646dd <unknown>+0x5f03b2c646dd (/data/local/tmp/ds2+0x5d6dd)
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00005f03b2c60977 <unknown>+0x5f03b2c60977 (/data/local/tmp/ds2+0x59977)
[10853][void ds2::Utils::PrintBacktrace()] ERROR  : 0x00007be7296c09f0 __libc_init+0x60 (/apex/com.android.runtime/lib64/bionic/libc.so+0x529f0)
```
Addresses relative to the module can be decoded on the build machine with `lldb-symbolizer`:
```
$ llvm-symbolizer --obj=./build/ds2 <stack.txt 
ds2::Utils::PrintBacktrace()
??:0:0

ds2::Log(int, char const*, char const*, char const*, ...)
??:0:0

ds2::Target::Linux::Process::wait()
??:0:0

ds2::GDBRemote::DebugSessionImplBase::onResume(ds2::GDBRemote::Session&, std::__ndk1::vector<ds2::GDBRemote::ThreadResumeAction, std::__ndk1::allocator<ds2::GDBRemote::ThreadResumeAction>> const&, ds2::GDBRemote::StopInfo&)
??:0:0

ds2::GDBRemote::Session::Handle_vCont(ds2::GDBRemote::ProtocolInterpreter::Handler const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)
??:0:0

ds2::GDBRemote::ProtocolInterpreter::onCommand(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)
??:0:0

ds2::GDBRemote::ProtocolInterpreter::onPacketData(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, bool)
??:0:0

ds2::GDBRemote::SessionBase::receive(bool)
??:0:0

RunDebugServer(ds2::Host::Channel*, ds2::GDBRemote::SessionDelegate*)
main.cpp:0:0

main
??:0:0
```
NOTE: file location debug information is also shown if ds2 is compiled with `-g`. 