### PR TITLE
explicitly map host name of * to 0.0.0.0 for compatibility

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -179,6 +179,12 @@ static std::unique_ptr<Socket> CreateSocket(std::string const &arg,
         // to strip the square brackets around the host part.
         if (addrString[0] == '[' && addrString[splitPos - 1] == ']') {
           host = addrString.substr(1, splitPos - 2);
+        } else if (splitPos == 1 && addrString[0] == '*') {
+          // Allow caller to specify a host name of * to listen on all available
+          // network interfaces. On some, but not all platforms, getaddrinfo()
+          // resolves * to 0.0.0.0 already. Explicitly making this substitution
+          // ensures the most compatibility.
+          host = "0.0.0.0";
         } else {
           host = addrString.substr(0, splitPos);
         }


### PR DESCRIPTION
On Fedora 40, `getaddrinfo()` resolves host name * to 0.0.0.0. However, on Android it does not, which leads to a number of lldb tests failling when run against a ds2 server. This change makes explicitly remaps the name prior to calling `getaddrinfo()` to ensure the most compatibility. On its own, this change does not enable more lldb tests to pass, but it is required for some upcoming changes to work when run against an Android target.

This change matches the behavior of lldb-server, which was added (back) in llvm/llvm-project@f57453aece3e1dc56ce00a29ec6612d33e521c88 to address similar test failures.