### PR TITLE
implement support for `vFile:mode` and `vFile:size` packets

### DIFF
--- a/Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h
@@ -245,6 +245,8 @@ protected: // Platform Session
                              uint8_t digest[16]) override;
   ErrorCode onFileGetSize(Session &session, std::string const &path,
                           uint64_t &size) override;
+  ErrorCode onFileGetMode(Session &session, std::string const &path,
+                          uint32_t &mode) const override;
 
   ErrorCode onQueryProcessList(Session &session, ProcessInfoMatch const &match,
                                bool first, ProcessInfo &info) const override;

--- a/Headers/DebugServer2/GDBRemote/Mixins/FileOperationsMixin.h
+++ b/Headers/DebugServer2/GDBRemote/Mixins/FileOperationsMixin.h
@@ -45,6 +45,10 @@ protected:
 
 protected:
   ErrorCode onFileExists(Session &session, std::string const &path) override;
+  ErrorCode onFileGetSize(Session &session, std::string const &path,
+                          uint64_t &size) override;
+  ErrorCode onFileGetMode(Session &session, std::string const &path,
+                          uint32_t &mode) const override;
   ErrorCode onFileRemove(Session &session, std::string const &path) override;
 
 protected:

--- a/Headers/DebugServer2/GDBRemote/SessionDelegate.h
+++ b/Headers/DebugServer2/GDBRemote/SessionDelegate.h
@@ -272,6 +272,8 @@ protected: // Platform Session
                                      uint8_t digest[16]) = 0;
   virtual ErrorCode onFileGetSize(Session &session, std::string const &path,
                                   uint64_t &size) = 0;
+  virtual ErrorCode onFileGetMode(Session &session, std::string const &path,
+                                  uint32_t &mode) const = 0;
 
   virtual ErrorCode onQueryProcessList(Session &session,
                                        ProcessInfoMatch const &match,

--- a/Headers/DebugServer2/Host/File.h
+++ b/Headers/DebugServer2/Host/File.h
@@ -63,6 +63,7 @@ public:
 
 public:
   static ErrorCode fileSize(std::string const &path, uint64_t &size);
+  static ErrorCode fileMode(std::string const &path, uint32_t &mode);
 
 protected:
   int _fd;

--- a/Sources/GDBRemote/DummySessionDelegateImpl.cpp
+++ b/Sources/GDBRemote/DummySessionDelegateImpl.cpp
@@ -293,6 +293,8 @@ DUMMY_IMPL_EMPTY(onFileComputeMD5, Session &, std::string const &, uint8_t[16])
 
 DUMMY_IMPL_EMPTY(onFileGetSize, Session &, std::string const &, uint64_t &)
 
+DUMMY_IMPL_EMPTY_CONST(onFileGetMode, Session &, std::string const &, uint32_t&)
+
 DUMMY_IMPL_EMPTY_CONST(onQueryProcessList, Session &, ProcessInfoMatch const &,
                        bool, ProcessInfo &)
 

--- a/Sources/GDBRemote/Mixins/FileOperationsMixin.hpp
+++ b/Sources/GDBRemote/Mixins/FileOperationsMixin.hpp
@@ -89,6 +89,19 @@ ErrorCode FileOperationsMixin<T>::onFileExists(Session &,
 }
 
 template <typename T>
+ErrorCode FileOperationsMixin<T>::onFileGetSize(Session &session, std::string const &path,
+                        uint64_t &size){
+  return Host::File::fileSize(path, size);
+}
+
+template <typename T>
+ErrorCode FileOperationsMixin<T>::onFileGetMode(Session &session,
+                                                std::string const &path,
+                                                uint32_t &mode) const {
+  return Host::File::fileMode(path, mode);
+}
+
+template <typename T>
 ErrorCode FileOperationsMixin<T>::onFileRemove(Session &session,
                                                std::string const &path) {
   return Host::File::unlink(path);

--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -3099,6 +3099,17 @@ void Session::Handle_vFile(ProtocolInterpreter::Handler const &,
     } else {
       ss << 'F' << std::hex << size;
     }
+  } else if (op == "mode") {
+    uint32_t mode;
+    ErrorCode error =
+        _delegate->onFileGetMode(*this, HexToString(&args[op_end]), mode);
+    // Response is F followed by the mode bits in base 16 or
+    // F-1,errno with the errno if an error occurs, base 16
+    if (error != kSuccess) {
+      ss << 'F' << -1 << ',' << std::hex << error;
+    } else {
+      ss << 'F' << std::hex << mode;
+    }
   } else {
     sendError(kErrorUnsupported);
     return;

--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -2964,6 +2964,7 @@ void Session::Handle_vFile(ProtocolInterpreter::Handler const &,
   //
   // LLDB: vFile:exists:path
   //       vFile:size:path
+  //       vFile:mode:path
   //       vFile:MD5:path
   //
   bool escaped = false;
@@ -3093,11 +3094,13 @@ void Session::Handle_vFile(ProtocolInterpreter::Handler const &,
     uint64_t size;
     ErrorCode error =
         _delegate->onFileGetSize(*this, HexToString(&args[op_end]), size);
-    // Fsize or Exx if error.
+    // Response is F followed by the file size in base 16 or
+    // F-1,errno with the errno if an error occurs, base 16.
+    ss << 'F';
     if (error != kSuccess) {
-      ss << 'E' << std::hex << error;
+      ss << -1 << std::hex << error;
     } else {
-      ss << 'F' << std::hex << size;
+      ss << std::hex << size;
     }
   } else if (op == "mode") {
     uint32_t mode;
@@ -3105,10 +3108,11 @@ void Session::Handle_vFile(ProtocolInterpreter::Handler const &,
         _delegate->onFileGetMode(*this, HexToString(&args[op_end]), mode);
     // Response is F followed by the mode bits in base 16 or
     // F-1,errno with the errno if an error occurs, base 16
+    ss << 'F';
     if (error != kSuccess) {
-      ss << 'F' << -1 << ',' << std::hex << error;
+      ss << -1 << ',' << std::hex << error;
     } else {
-      ss << 'F' << std::hex << mode;
+      ss << std::hex << mode;
     }
   } else {
     sendError(kErrorUnsupported);

--- a/Sources/Host/POSIX/File.cpp
+++ b/Sources/Host/POSIX/File.cpp
@@ -163,5 +163,14 @@ ErrorCode File::fileSize(std::string const &path, uint64_t &size) {
   size = static_cast<uint64_t>(stbuf.st_size);
   return kSuccess;
 }
+
+ErrorCode File::fileMode(std::string const &path, uint32_t &mode) {
+  struct stat stbuf;
+  if (stat(path.c_str(), &stbuf) < 0)
+    return Platform::TranslateError();
+
+  mode = static_cast<uint32_t>(ALLPERMS & stbuf.st_mode);
+  return kSuccess;
+}
 } // namespace Host
 } // namespace ds2

--- a/Sources/Host/Windows/File.cpp
+++ b/Sources/Host/Windows/File.cpp
@@ -42,5 +42,10 @@ ErrorCode File::createDirectory(std::string const &path, uint32_t flags) {
 ErrorCode File::fileSize(std::string const &path, uint64_t &size) {
   return kErrorUnsupported;
 }
+
+ErrorCode File::fileMode(std::string const &path, uint32_t &mode) {
+  return kErrorUnsupported;
+}
+
 } // namespace Host
 } // namespace ds2


### PR DESCRIPTION
## Purpose
Implement responses to the `vFile:mode` and `vFile:size` packets in ds2 platform and debug server sessions. Fully addresses issue #136.  

## Overview
* Add `File::fileMode` support to the `Host::File` interface
* Implement the POSIX version of `Host::File::fileMode` using `stat(2)`
* Stub-out the Windows implementation of `Host::File::fileMode`
* Override and implement the existing `SessionDelegate::onFileGetSize` method in `FileOperationsMixin` to call the exiting `Host::File::fileSize` method
* Add a new `SessionDelegate::onFileGetMode` method and override it in `FileOperationsMixin` to call the new `Host::File::fileMode` method
* Fix error response of `vFile:size` to match the lldb documentation.

## Problem Details
DS2 does not properly implement responses to the `vFile:mode` and `vFile:size` packets. These packets are documented [here](https://lldb.llvm.org/resources/lldbgdbremote.html#vfile-packets). Most of the pieces for `vFile:size` were already present, but they were not all tied together.

## Validation
With some other uncommitted local patches, verify the following lldb test cases pass on Android and Linux:

```
TestGdbRemotePlatformFile.TestGdbRemotePlatformFile.test_platform_file_mode_fail_llgs
TestGdbRemotePlatformFile.TestGdbRemotePlatformFile.test_platform_file_mode_llgs
TestGdbRemotePlatformFile.TestGdbRemotePlatformFile.test_platform_file_size_llgs
```

These test cases will be re-enabled in CI testing after this and a number of other patches are merged.
