### PR TITLE
properly support append mode with the `vFile:open` packet

### DIFF
--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -273,6 +273,9 @@ OpenFlags Session::ConvertOpenFlags(uint32_t protocolFlags) {
     return kOpenFlagInvalid; // Invalid mode
   }
 
+  if (protocolFlags & 0x8)
+    flags |= kOpenFlagAppend;
+
   flags = flags
     | (protocolFlags & 0x200 ? kOpenFlagCreate : 0) // eOpenOptionCanCreate (O_CREAT)
     | (protocolFlags & 0x400 ? kOpenFlagTruncate : 0) // eOpenOptionTruncate (O_TRUNC)


### PR DESCRIPTION
The changes made in compnerd/ds2@30b6a55445e28b52004648ed568b22379d6c5944 inadvertently dropped support for append mode in `vFile:open`. This PR adds back support.

## Validation
With this change and some other local patches, the following lldb test cases now pass on Android and Linux:
```
TestGdbRemotePlatformFile.TestGdbRemotePlatformFile.test_platform_file_rdwr_append_llgs
TestGdbRemotePlatformFile.TestGdbRemotePlatformFile.test_platform_file_wronly_append_llgs
```

These tests will be re-enabled once this change and several others are merged.