### PR TITLE
[gha] ensure the FreeBSD build job fails when there are compilation failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,7 +250,10 @@ jobs:
                   -G Ninja                                                    \
                   -S ${{ github.workspace }}/SourceCache/ds2
             cmake --build ${{ github.workspace }}/BinaryCache/ds2 --config Release
-            tar -C ${{ github.workspace }}/BinaryCache -cvf ${{ github.workspace }}/BinaryCache/ds2.tar ds2
+
+      # Tar the output to preserve permissions.
+      - name: tar output
+        run: tar -C ${{ github.workspace }}/BinaryCache -cvf ${{ github.workspace }}/BinaryCache/ds2.tar ds2
 
       - uses: actions/upload-artifact@v4
         with:

--- a/Sources/Host/FreeBSD/Platform.cpp
+++ b/Sources/Host/FreeBSD/Platform.cpp
@@ -36,9 +36,9 @@ static struct utsname const *GetCachedUTSName() {
 
 char const *Platform::GetOSVersion() { return GetCachedUTSName()->release; }
 
-char const *Platform::GetOSBuild() { return GetCachedUTSName()->version; }
+char const *Platform::GetOSBuild() { return GetCachedUTSName()->release; }
 
-char const *Platform::GetOSKernelPath() { return nullptr; }
+char const *Platform::GetOSKernelVersion() { return GetCachedUTSName()->version; }
 
 const char *Platform::GetSelfExecutablePath() {
   return Host::FreeBSD::ProcStat::GetExecutablePath(getpid()).c_str();


### PR DESCRIPTION
## Purpose
The FreeBSD build was silently failing for a week or so but the GitHub build job was succeeding anyway. This looks like a quirk in the `vmactions/freebsd-vm`  action, where it reports the exit code of the last command run. This PR ensures the last command run is actually the `cmake --build` command.

## Overview
* Move the `tar` command for the build output out of the VM and back to the job runner to ensure the last command run in the VM is `cmake --build`.
* Fix the build error introduced by compnerd/ds2@0cf4f7498ed84e321c5b4f77be2aa190385add15 by renaming FreeBSD's `Platform::GetOSKernelPath` with `Platform::GetOSKernelVersion` as was done for Linux.
* Update FreeBSD's `Platform::GetOSBuild` to report `uname`'s `release` string rather than `version`, as was previously done for Linux.

## Validation
Confirmed the [FreeBSD build](https://github.com/andrurogerz/ds2/actions/runs/11185227567/job/31102210878) breaks in its current state by applying 0cf4f7498ed84e321c5b4f77be2aa190385add15 only.