### PR TITLE
add support for the vFile:fstat packet

### DIFF
--- a/Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h
@@ -247,6 +247,8 @@ protected: // Platform Session
                           uint64_t &size) override;
   ErrorCode onFileGetMode(Session &session, std::string const &path,
                           uint32_t &mode) const override;
+  ErrorCode onFileFstat(Session &session, int fd,
+                       ByteVector &buffer) const override;
 
   ErrorCode onQueryProcessList(Session &session, ProcessInfoMatch const &match,
                                bool first, ProcessInfo &info) const override;

--- a/Headers/DebugServer2/GDBRemote/Mixins/FileOperationsMixin.h
+++ b/Headers/DebugServer2/GDBRemote/Mixins/FileOperationsMixin.h
@@ -49,6 +49,7 @@ protected:
                           uint64_t &size) override;
   ErrorCode onFileGetMode(Session &session, std::string const &path,
                           uint32_t &mode) const override;
+  ErrorCode onFileFstat(Session &session, int fd, ByteVector &buffer) const override;
   ErrorCode onFileRemove(Session &session, std::string const &path) override;
 
 protected:

--- a/Headers/DebugServer2/GDBRemote/SessionDelegate.h
+++ b/Headers/DebugServer2/GDBRemote/SessionDelegate.h
@@ -274,6 +274,8 @@ protected: // Platform Session
                                   uint64_t &size) = 0;
   virtual ErrorCode onFileGetMode(Session &session, std::string const &path,
                                   uint32_t &mode) const = 0;
+  virtual ErrorCode onFileFstat(Session &session, int fd,
+                               ByteVector &buffer) const = 0;
 
   virtual ErrorCode onQueryProcessList(Session &session,
                                        ProcessInfoMatch const &match,

--- a/Headers/DebugServer2/Host/File.h
+++ b/Headers/DebugServer2/Host/File.h
@@ -47,6 +47,7 @@ public:
 public:
   ErrorCode pread(ByteVector &buf, uint64_t &count, uint64_t offset);
   ErrorCode pwrite(ByteVector const &buf, uint64_t &count, uint64_t offset);
+  ErrorCode fstat(ByteVector &buffer) const;
 
 public:
   bool valid() const { return (_fd >= 0); }

--- a/Sources/GDBRemote/DummySessionDelegateImpl.cpp
+++ b/Sources/GDBRemote/DummySessionDelegateImpl.cpp
@@ -295,6 +295,8 @@ DUMMY_IMPL_EMPTY(onFileGetSize, Session &, std::string const &, uint64_t &)
 
 DUMMY_IMPL_EMPTY_CONST(onFileGetMode, Session &, std::string const &, uint32_t&)
 
+DUMMY_IMPL_EMPTY_CONST(onFileFstat, Session &, int, ByteVector &)
+
 DUMMY_IMPL_EMPTY_CONST(onQueryProcessList, Session &, ProcessInfoMatch const &,
                        bool, ProcessInfo &)
 

--- a/Sources/GDBRemote/Mixins/FileOperationsMixin.hpp
+++ b/Sources/GDBRemote/Mixins/FileOperationsMixin.hpp
@@ -102,6 +102,17 @@ ErrorCode FileOperationsMixin<T>::onFileGetMode(Session &session,
 }
 
 template <typename T>
+ErrorCode FileOperationsMixin<T>::onFileFstat(Session &session, int fd,
+                      ByteVector &buffer) const {
+  auto it = _openFiles.find(fd);
+  if (it == _openFiles.end()) {
+    return kErrorInvalidHandle;
+  }
+
+  return it->second.fstat(buffer);
+}
+
+template <typename T>
 ErrorCode FileOperationsMixin<T>::onFileRemove(Session &session,
                                                std::string const &path) {
   return Host::File::unlink(path);

--- a/Sources/GDBRemote/Mixins/FileOperationsMixin.hpp
+++ b/Sources/GDBRemote/Mixins/FileOperationsMixin.hpp
@@ -105,9 +105,8 @@ template <typename T>
 ErrorCode FileOperationsMixin<T>::onFileFstat(Session &session, int fd,
                       ByteVector &buffer) const {
   auto it = _openFiles.find(fd);
-  if (it == _openFiles.end()) {
+  if (it == _openFiles.end())
     return kErrorInvalidHandle;
-  }
 
   return it->second.fstat(buffer);
 }

--- a/Sources/Host/POSIX/File.cpp
+++ b/Sources/Host/POSIX/File.cpp
@@ -141,7 +141,7 @@ ErrorCode File::fstat(ByteVector &buffer) const {
   const auto appendInteger = [&buffer](auto value) -> void {
     buffer.insert(buffer.end(),
                   reinterpret_cast<uint8_t*>(&value),
-                  reinterpret_cast<uint8_t*>(&value + 1));
+                  reinterpret_cast<uint8_t*>(&value) + sizeof(value));
   };
 
   appendInteger(htobe32(static_cast<uint32_t>(s.st_dev)));

--- a/Sources/Host/POSIX/File.cpp
+++ b/Sources/Host/POSIX/File.cpp
@@ -16,6 +16,16 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#if defined(OS_LINUX)
+#include <endian.h>
+#elif defined(OS_FREEBSD)
+#include <sys/_endian.h>
+#elif defined(OS_DARWIN)
+#include <libkern/OSByteOrder.h>
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#endif
+
 namespace ds2 {
 namespace Host {
 
@@ -116,6 +126,40 @@ ErrorCode File::pwrite(ByteVector const &buf, uint64_t &count,
   count = static_cast<uint64_t>(nWritten);
 
   return _lastError = kSuccess;
+}
+
+// lldb expects stat data is returned as a packed buffer with total size of 64
+// bytes. The field order is the same as the POSIX defined stat struct. All
+// fields are encoded as 4-byte, big-endian unsigned integers except for
+// st_size, st_blksize, and st_blocks which are all 8-byte, big-endian unsigned
+// integers.
+ErrorCode File::fstat(ByteVector &buffer) const {
+  struct stat s;
+  if (::fstat(_fd, &s) < 0)
+    return Platform::TranslateError();
+
+  const auto appendInteger = [&buffer](auto value) -> void {
+    buffer.insert(buffer.end(),
+                  reinterpret_cast<uint8_t*>(&value),
+                  reinterpret_cast<uint8_t*>(&value + 1));
+  };
+
+  appendInteger(htobe32(static_cast<uint32_t>(s.st_dev)));
+  appendInteger(htobe32(static_cast<uint32_t>(s.st_ino)));
+  appendInteger(htobe32(static_cast<uint32_t>(s.st_mode)));
+  appendInteger(htobe32(static_cast<uint32_t>(s.st_nlink)));
+  appendInteger(htobe32(static_cast<uint32_t>(s.st_uid)));
+  appendInteger(htobe32(static_cast<uint32_t>(s.st_gid)));
+  appendInteger(htobe32(static_cast<uint32_t>(s.st_rdev)));
+  appendInteger(htobe64(static_cast<uint64_t>(s.st_size)));
+  appendInteger(htobe64(static_cast<uint64_t>(s.st_blksize)));
+  appendInteger(htobe64(static_cast<uint64_t>(s.st_blocks)));
+  appendInteger(htobe32(static_cast<uint32_t>(s.st_atime)));
+  appendInteger(htobe32(static_cast<uint32_t>(s.st_mtime)));
+  appendInteger(htobe32(static_cast<uint32_t>(s.st_ctime)));
+  DS2ASSERT(buffer.size() == 64);
+
+  return kSuccess;
 }
 
 ErrorCode File::chmod(std::string const &path, uint32_t mode) {

--- a/Sources/Host/Windows/File.cpp
+++ b/Sources/Host/Windows/File.cpp
@@ -29,6 +29,10 @@ ErrorCode File::pwrite(ByteVector const &buf, uint64_t &count,
   return kErrorUnsupported;
 }
 
+ErrorCode File::fstat(ByteVector &buffer) const {
+  return kErrorUnsupported;
+}
+
 ErrorCode File::chmod(std::string const &path, uint32_t mode) {
   return kErrorUnsupported;
 }


### PR DESCRIPTION
## Purpose
Add support for lldb's `vFile:fstat` packet to ds2 debug and platform sessions. Fixes #135. 

## Overview
* Add `fstat` method to the `File` class and implement it for POSIX. Leave the Windows implementation unimplemented (as is the rest of `File`)
* Call the new `File::fstat` method when is `vFile:fstat` packet is received.

## Problem Details
Several of the lldb tests rely on `vFile:fstat` to fetch files from the device, and these tests fail against ds2 because it is not implemented.

The `vFile:fstat` packet isn't documented. The implementation is based on the expectation of the lldb test case `TestGdbRemotePlatformFile.TestGdbRemotePlatformFile.test_platform_file_fstat_llgs`, which now passes with this change.

## Validation
Once this PR and a some additionalchanges are merged, most of the `TestGdbRemotePlatformFile` tests succeed with ds2 running on Android and Linux and can be enabled in CI. They do not all pass with this PR alone.