### PR TITLE
[posix] remove setgid(2)/setsid(2) from ProcessSpawner

### DIFF
--- a/Sources/Target/POSIX/Process.cpp
+++ b/Sources/Target/POSIX/Process.cpp
@@ -148,6 +148,14 @@ ds2::Target::Process *Process::Create(ProcessSpawner &spawner) {
   auto process = ds2::make_unique<Target::Process>();
 
   if (spawner.run([&process]() {
+        // move debug targets to their own process group
+        if (::setpgid(0, 0) != 0)
+          return false;
+
+        // drop the setgid ability of debug targets
+        if (::setgid(::getgid()) != 0)
+          return false;
+
         return process->ptrace().traceMe(true) == kSuccess;
       }) != kSuccess) {
     return nullptr;


### PR DESCRIPTION
## Purpose
Remove the call to `setsid(2)` on every process spawn and make debug inferior process setup items specific to `DebugSession` launched process. This PR makes ds2 process launch behavior consistent with lldb-server. Addresses issue #137 along with PR #143. 

## Overview
* Eliminate the call to `setsid(2)` from `ProcessSpawner`
* Call `setpgid(2)` from the `preExecAction` callback for `DebugSession` process launch. Do not make this call for generic process launch (which again matches `lldb-server`'s behavior).
* Move the call to `setgid(2)` from the `ProcessSpawner` implementation into the `preExecAction` callback for `DebugSession` process launch. This move avoids making the call when launching processes that are not debug targets.

## Background
It is unclear why there was a call to `setsid(2)` on every process spawn. The implementation of `lldb-server` does not do this.

When launching a new gdb server instance of ds2 via the `qLaunchGDBServer`, it always passes along the `--setsid` argument so spawned gdb servers already call `setsid(2)`. When spawning other processes, including debug inferiors, there is no need to make this call; doing so can cause some test failures/hangs due to undelivered signals because the inferior is in a different session.

## Validation
Once this PR and #143 are merged, most of the TestGdbRemote* and TestLldbGdbServer* lldb tests succeed with ds2 running on Android and Linux and can be enabled in CI. They do not all pass with this PR alone.