### PR TITLE
`QSaveRegisterState` and `QRestoreRegisterState` packets may not include thread suffix

### DIFF
--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -672,7 +672,12 @@ ErrorCode DebugSessionImplBase::onSaveRegisters(Session &session,
                                                 uint64_t &id) {
   static uint64_t counter = 1;
 
-  Thread *thread = findThread(ptid);
+  Thread *thread = nullptr;
+  if (ptid.valid())
+    thread = findThread(ptid);
+  else if (_process != nullptr)
+    thread = _process->currentThread();
+
   if (thread == nullptr)
     return kErrorProcessNotFound;
 
@@ -687,7 +692,12 @@ ErrorCode DebugSessionImplBase::onSaveRegisters(Session &session,
 ErrorCode DebugSessionImplBase::onRestoreRegisters(Session &session,
                                                    ProcessThreadId const &ptid,
                                                    uint64_t id) {
-  Thread *thread = findThread(ptid);
+  Thread *thread = nullptr;
+  if (ptid.valid())
+    thread = findThread(ptid);
+  else if (_process != nullptr)
+    thread = _process->currentThread();
+
   if (thread == nullptr)
     return kErrorProcessNotFound;
 


### PR DESCRIPTION
## Purpose
Fix the implementation of `QSaveRegisterState` and `QRestoreRegisterState` to work even with no thread identifier, per the [lldb packet documentation](https://lldb.llvm.org/resources/lldbgdbremote.html#qrestoreregisterstate-save-id-qrestoreregisterstate-save-id-thread-xxxx).

## Overview
* Fix handling of `QSaveRegisterState` to use the current thread if none was specified in the packet arguments.
* Fix handling of `QSRestoreRegisterState` to use the current thread if none was specified in the packet arguments.

## Validation
With PR #143 applied, the `TestGdbRemoteRegisterState.test_grp_register_save_restore_works_no_suffix_llgs` passes locally running against DS2 on Linux x86_64.