### PR TITLE
add support for the vRun GDB packet

### DIFF
--- a/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
@@ -145,6 +145,9 @@ protected:
 protected:
   ErrorCode onAttach(Session &session, ProcessId pid, AttachMode mode,
                      StopInfo &stop) override;
+  ErrorCode onRunAttach(Session &session, std::string const &filename,
+                        StringCollection const &arguments,
+                        StopInfo &stop) override;
 
 protected:
   ErrorCode onResume(Session &session,

--- a/Headers/DebugServer2/Host/POSIX/ProcessSpawner.h
+++ b/Headers/DebugServer2/Host/POSIX/ProcessSpawner.h
@@ -112,6 +112,9 @@ public:
   inline ProcessId pid() const { return _pid; }
   inline int exitStatus() const { return _exitStatus; }
   inline int signalCode() const { return _signalCode; }
+  inline std::string const &executable() const { return _executablePath; }
+  inline StringCollection const &arguments() const { return _arguments; }
+  inline EnvironmentBlock const &environment() const { return _environment; }
 
 public:
   ErrorCode input(ByteVector const &buf);

--- a/Headers/DebugServer2/Host/Windows/ProcessSpawner.h
+++ b/Headers/DebugServer2/Host/Windows/ProcessSpawner.h
@@ -91,6 +91,9 @@ public:
   inline HANDLE threadHandle() const { return _threadHandle; }
   inline int exitStatus() const { return 0; }
   inline int signalCode() const { return 0; }
+  inline std::string const &executable() const { return _executablePath; }
+  inline StringCollection const &arguments() const { return _arguments; }
+  inline EnvironmentBlock const &environment() const { return _environment; }
 
 public:
   ErrorCode input(ByteVector const &buf) { return kErrorUnsupported; }

--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -3233,7 +3233,7 @@ void Session::Handle_vRun(ProtocolInterpreter::Handler const &,
   size_t index = 0;
 
   ParseList(args, ';', [&](std::string const &arg) {
-    if (index == 0) {
+    if (index++ == 0) {
       filename = HexToString(arg);
     } else {
       arguments.push_back(HexToString(arg));


### PR DESCRIPTION
## Purpose
Add support for GDB's `vRun` packet to ds2 debug sessions. Fixes issue #150. 

## Overview
* Override `SessionDelegate::onRunAttach` in `DebugSession`. Use existing `spawnProcess` method to actually launch the process.
* Preserve environment variables set on `_spawner` by previous calls to `onSetEnvironmentVariable`.
* Preserve previous executable and arguments set on `_spawner` from previous calls to `onRunAttach`.
* Update `spawnProcess` to use memoized executable, arguments, and environment when new ones are not provided.
* Fix missing `index++` in `Session::Handle_vRun.

## Problem Details
The following test cases rely on the `vRun` packet to work properly in the debug session:
```
GdbRemoteLaunchTestCase.test_QEnvironmentHexEncoded_llgs
GdbRemoteLaunchTestCase.test_QEnvironment_llgs
GdbRemoteLaunchTestCase.test_launch_via_vRun_llgs
GdbRemoteLaunchTestCase.test_launch_via_vRun_no_args_llgs
```

## Validation
Combined with PR #143, this change gets all of the `GdbRemoteLaunchTestCase` test cases passing against ds2 running on Linux x86_64.