### PR TITLE
fix build issues when building for Android on Windows

### DIFF
--- a/Sources/Utils/Backtrace.cpp
+++ b/Sources/Utils/Backtrace.cpp
@@ -11,7 +11,7 @@
 #include "DebugServer2/Utils/Backtrace.h"
 #include "DebugServer2/Utils/Log.h"
 
-#if defined(ANDROID) || defined(OS_DARWIN) || defined(__GLIBC__)
+#if defined(PLATFORM_ANDROID) || defined(OS_DARWIN) || defined(__GLIBC__)
 #include <cxxabi.h>
 #include <dlfcn.h>
 #include <execinfo.h>
@@ -22,7 +22,7 @@
 #include <sstream>
 #endif
 
-#if defined(ANDROID)
+#if defined(PLATFORM_ANDROID)
 // Android provides libunwind in the NDK instead of glibc backtrace
 #include <unwind.h>
 #endif
@@ -30,7 +30,7 @@
 namespace ds2 {
 namespace Utils {
 
-#if defined(ANDROID)
+#if defined(PLATFORM_ANDROID)
 struct unwind_state {
     void **buffer_cursor;
     void **buffer_end;
@@ -66,7 +66,7 @@ static int UnwindBacktrace(void *stack_buffer[], int stack_size) {
 }
 #endif
 
-#if defined(ANDROID) || defined(OS_DARWIN) || (defined(__GLIBC__) && !defined(PLATFORM_TIZEN))
+#if defined(PLATFORM_ANDROID) || defined(OS_DARWIN) || (defined(__GLIBC__) && !defined(PLATFORM_TIZEN))
 static void PrintBacktraceEntrySimple(void *address) {
   DS2LOG(Error, "%" PRI_PTR, PRI_PTR_CAST(address));
 }

--- a/Tools/JSObjects/CMakeLists.txt
+++ b/Tools/JSObjects/CMakeLists.txt
@@ -68,6 +68,7 @@ if((CMAKE_C_COMPILER_ID MATCHES "GNU" AND
     _POSIX_C_SOURCE=200809L)
   target_compile_options(jsobjects PRIVATE -Wall -Wextra -Werror)
   target_compile_options(jsobjects PRIVATE
+    -Wno-macro-redefined
     -Wno-unused-parameter
     -Wno-unused-function
     -Wno-sign-compare)


### PR DESCRIPTION
* Set `-Wno-macro-redefined` when building JSObjects because the code generated by flex/bison generates this warning
* Gate backtrace implementation with `PLATFORM_ANDROID` because `ANDROID` is not defined when building for Windows