### PR TITLE
succeed `qModuleInfo` when ELF file has no build ID

### DIFF
--- a/Sources/GDBRemote/Mixins/FileOperationsMixin.hpp
+++ b/Sources/GDBRemote/Mixins/FileOperationsMixin.hpp
@@ -130,23 +130,23 @@ ErrorCode FileOperationsMixin<T>::onQueryModuleInfo(Session &session,
                                                      std::string &triple,
                                                      ModuleInfo &info) const {
   ByteVector buildId;
-  if (!Platform::GetExecutableFileBuildID(path, buildId))
-    return kErrorUnknown;
+  if (Platform::GetExecutableFileBuildID(path, buildId)) {
+    // format the uuid as an upper-case string with two hex chars per byte
+    std::ostringstream ss;
+    for(const auto b : buildId)
+      ss << std::uppercase << std::hex << std::setfill('0') << std::setw(2) << int(b);
+
+    info.uuid = ss.str();
+  }
 
   // TODO(andrurogerz): Not all executable files contain an embedded build ID.
   // If GetExecutableFileBuildID fails, calculate an md5 hash of the file
   // contents and return that as an "md5" field instead of the "uuid" field.
 
-  // send the uuid as a hex-encoded, upper-case string
-  std::ostringstream ss;
-  for(const auto b : buildId)
-    ss << std::uppercase << std::hex << std::setfill('0') << std::setw(2) << int(b);
-
   auto error = File::fileSize(path, info.file_size);
   if (error != kSuccess)
     return error;
 
-  info.uuid = ss.str();
   info.triple = triple;
   info.file_path = path;
   info.file_offset = 0;

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -847,7 +847,8 @@ std::string ProgramResult::encode() const {
 
 std::string ModuleInfo::encode() const {
   std::ostringstream ss;
-  ss << "uuid:" << ToHex(uuid) << ";";
+  if (!uuid.empty())
+    ss << "uuid:" << ToHex(uuid) << ";";
   ss << "triple:" << ToHex(triple) << ";";
   ss << "file_path:" << ToHex(file_path) << ";";
   ss << "file_offset:" << HEX(16) << file_offset << ";";


### PR DESCRIPTION
## Overview
The ds2 implementation for handling the `qModuleInfo` packet fails when it is unable to retrieve an ELF build ID from the module. This failure causes `lldb` to stop fetching info for subsequent modules. This PR addresses the issue by making `qModuleInfo` succeed in this case and excluding the `uuid` field from the response.

## Validation
GitHub build & test
Locally verified debugging a Swift test that imports modules w/out build IDs. Images for all modules with build IDs load and symbols resolve correctly.