### PR TITLE
[gha] remove `stdout` from test logs to reduce verbosity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -446,12 +446,12 @@ jobs:
       - run: |
           mkdir -p ${{ github.workspace }}/temp
           ${{ github.workspace }}/BinaryCache/ds2/ds2 platform --server --daemonize --listen localhost:5432
-          ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest  \
-              --out-of-tree-debugserver                             \
-              --arch ${{ matrix.arch }}                             \
-              --platform-name remote-linux                          \
-              --platform-url connect://localhost:5432               \
-              --platform-working-dir ${{ github.workspace }}/temp   \
+          ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest 1>/dev/null  \
+              --out-of-tree-debugserver                                         \
+              --arch ${{ matrix.arch }}                                         \
+              --platform-name remote-linux                                      \
+              --platform-url connect://localhost:5432                           \
+              --platform-working-dir ${{ github.workspace }}/temp               \
               --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/linux-${{ matrix.arch }}.excluded \
               --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/ds2/linux-${{ matrix.arch }}.excluded \
               --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/non-debugserver-tests.excluded \
@@ -599,7 +599,7 @@ jobs:
 
             $ANDROID_SDK_ROOT/platform-tools/adb shell "/data/local/tmp/ds2 platform --server --daemonize --listen localhost:5432"
 
-            ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest
+            ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest 1>/dev/null
             --out-of-tree-debugserver
             --arch ${{ matrix.llvm-arch }}
             --platform-name remote-android


### PR DESCRIPTION
## Purpose
Reduce the unnecessary logging produced when running `lldb-dotest`.

## Overview
* Suppress `stdout` when running `lldb-dotest` since all of the useful output, including pass/fail logs, goes to `stderr`
* Reduces the log size so that they entirely fit in the GitHub log view page-- there is no need to download the log archive to find which test case failed
* Reduces the test run time by multiple minutes

## Validation
Run GitHub build & test job on this PR.