### PR TITLE
allow ELF link audit version <= LAV_CURRENT

### DIFF
--- a/Sources/Target/POSIX/ELFProcess.cpp
+++ b/Sources/Target/POSIX/ELFProcess.cpp
@@ -191,7 +191,7 @@ EnumerateLinkMap(ELFProcess *process, Address addressToDPtr,
 // Android and FreeBSD don't have a definition for LAV_CURRENT so we skip this
 // check.
 #if defined(LAV_CURRENT)
-  if (debug.version != LAV_CURRENT) {
+  if (debug.version > LAV_CURRENT) {
     return kErrorUnsupported;
   }
 #endif


### PR DESCRIPTION
## Purpose
Check the link audit version the ELF debug header is not greater than the current version, `LAV_CURRENT` rather than exactly equal to it.

## Background
On a recent Linux host, `LAV_CURRENT` is defined as 2, while modules may be 1 or 2. Changing the check this way allows both v1 and v2 modules to load, which is safe since the header layouts did not between versions.

## Validation
Manually ran `image list` from lldb when attached to a `remote-linux` ds2 server (on Fedora 40) and verified the list of modules matches the list generated when doing the same against an lldb-server instance.