### PR TITLE
[android] update README for building and running on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The build instructions include instructions assuming that the [ninja-build](http
   - flex
   - bison
 
+**Android**
+  - Android NDK r18b or newer (https://developer.android.com/ndk/downloads)
+
 ### Building with CMake + Ninja
 
 > **Windows Only**
@@ -41,13 +44,22 @@ ninja -C out
 ### Compiling for Android
 
 For Android native debugging, it is possible to build ds2 with the Android NDK.
+An NDK version of at least r18b is required for C++17 support.
 
+CMake will automatically find the installed Android NDK if either the
+`ANDROID_NDK_ROOT` or `ANDROID_NDK` environment variable is set. Alternatively,
+the NDK location can be provided to CMake directly with the `CMAKE_ANDROID_NDK`
+variable, e.g. `-DCMAKE_ANDROID_NDK=/home/user/Android/Sdk/ndk/26.1.10909125`.
+
+To build for Android:
 ```sh
-cmake -B out -D CMAKE_SYSTEM_NAME=Android -D CMAKE_ANDROID_ARCH_ABI=armeabi-v7a -G Ninja -S ds2
-ninja -C out
+cd ds2
+mkdir build
+cmake -B build -S . -DCMAKE_SYSTEM_NAME=Android -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_BUILD_TYPE=Release -G Ninja
+cmake --build build --config Release
 ```
 
-Note that this will build ds2 targeting the highest level API level that the
+By default, CMake will build ds2 targeting the highest level API level that the
 NDK supports. If you want to target another api level, e.g. 21, add the flag
 `-DCMAKE_SYSTEM_VERSION=21` to your CMake invocation.
 
@@ -67,19 +79,23 @@ make
 This will generate a binary that you can copy to your device to start
 debugging.
 
-
-
 ## Running ds2
 
 ### Example
 
 #### On the remote host
 
-Launch ds2 with something like:
+Launch ds2 in platform mode (not supported on Windows):
+```sh
+$ ./ds2 platform --server --listen localhost:4242
+```
 
-    $ ./ds2 gdbserver localhost:4242 /path/to/TestSimpleOutput
+Launch ds2 as a single-instance gdb server debugging a program:
+```sh
+$ ./ds2 gdbserver localhost:4242 /path/to/TestSimpleOutput
+```
 
-ds2 is now ready to accept connections on port 4242 from lldb.
+In both cases, ds2 is ready to accept connections on port 4242 from lldb.
 
 #### On your local host
 

--- a/README.md
+++ b/README.md
@@ -179,18 +179,18 @@ Once connected in platform mode, you can select the program to be run using the
 If ds2 was launched in `gdbserver` mode, lldb can connect to it with the
 `gdb-remote` command:
 ```
-$ lldb /path/to/TestSimpleOutput
-Current executable set to '/path/to/TestSimpleOutput' (x86_64).
+$ lldb /path/to/executable
+Current executable set to '/path/to/executable' (x86_64).
 (lldb) gdb-remote localhost:4242
 Process 8336 stopped
-* thread #1: tid = 8336, 0x00007ffff7ddb2d0, name = 'TestSimpleOutput', stop reason = signal SIGTRAP
+* thread #1: tid = 8336, 0x00007ffff7ddb2d0, name = 'executable', stop reason = signal SIGTRAP
     frame #0: 0x00007ffff7ddb2d0
 -> 0x7ffff7ddb2d0:  movq   %rsp, %rdi
    0x7ffff7ddb2d3:  callq  0x7ffff7ddea70
    0x7ffff7ddb2d8:  movq   %rax, %r12
    0x7ffff7ddb2db:  movl   0x221b17(%rip), %eax
 (lldb) b main
-Breakpoint 1: where = TestSimpleOutput`main + 29 at TestSimpleOutput.cpp:6, address = 0x000000000040096d
+Breakpoint 1: where = executable`main + 29 at test.cpp:6, address = 0x000000000040096d
 [... debug debug ...]
 (lldb) c
 Process 8336 resuming

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ ./ds2 platform --server --listen localhost:4242
 
 Launch ds2 as a single-instance gdb server debugging a program:
 ```sh
-$ ./ds2 gdbserver localhost:4242 /path/to/TestSimpleOutput
+$ ./ds2 gdbserver localhost:4242 /path/to/executable
 ```
 
 In both cases, ds2 is ready to accept connections on port 4242 from lldb.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ variable, e.g. `-DCMAKE_ANDROID_NDK=/home/user/Android/Sdk/ndk/26.1.10909125`.
 To build for Android:
 ```sh
 cd ds2
-mkdir build
-cmake -B build -S . -DCMAKE_SYSTEM_NAME=Android -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_BUILD_TYPE=Release -G Ninja
-cmake --build build --config Release
+cmake -B out -S . -D CMAKE_SYSTEM_NAME=Android -D CMAKE_ANDROID_ARCH_ABI=arm64-v8a -D CMAKE_BUILD_TYPE=Release -G Ninja
+cmake --build out
 ```
 
 By default, CMake will build ds2 targeting the highest level API level that the

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $ lldb
 Once connected in platform mode, you can select the program to be run using the
 `file` command, run, and debug.
 ```
-(lldb) file /path/to/TestSimpleOutput
+(lldb) file /path/to/executable
 (lldb) b main
 (lldb) run
 ```


### PR DESCRIPTION
## Purpose
Cleanup and enhance the README file for build and running ds2 on Android.

## Overview
* Clarify how to build with the Android NDK and for Android in general
* Add instructions on running on Android, using adb, etc
* Add instructions on running in platform mode
* Overall cleanup

## Validation
Inspected the rendered contents [here](https://github.com/andrurogerz/ds2/tree/cleanup-readme).