### PR TITLE
[gha] build lldb with lzma enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,6 +313,10 @@ jobs:
         runner: [ubuntu-latest, ubuntu-24.04-arm]
 
     steps:
+      - name: Install LZMA libraries
+        run:
+          sudo apt install lzma-dev liblzma-dev
+
       - if: ${{ !contains(matrix.runner, 'arm') }}
         uses: seanmiddleditch/gha-setup-ninja@v5
 
@@ -349,6 +353,7 @@ jobs:
                 -D LLVM_ENABLE_PROJECTS='clang;lldb'                            \
                 -D LLVM_TARGETS_TO_BUILD="host"                                 \
                 -D LLDB_ENABLE_PYTHON=On                                        \
+                -D LLDB_ENABLE_LZMA=On                                          \
                 -D CMAKE_C_COMPILER_LAUNCHER=sccache                            \
                 -D CMAKE_CXX_COMPILER_LAUNCHER=sccache                          \
                 -D CMAKE_BUILD_TYPE=Release                                     \


### PR DESCRIPTION
## Purpose
Add lzma support to the version of lldb built to run lldb tests against ds2. This addition eliminates the following warnings that previously appeared when running the tests on Android:
```
warning: (x86_64) /home/runner/.lldb/module_cache/remote-android/.cache/27659E9D-B4F4-B4D2-71C0-6A6D79C81CBA/libm.so No LZMA support found for reading .gnu_debugdata section
warning: (x86_64) /home/runner/.lldb/module_cache/remote-android/.cache/32A6676D-6870-2632-466C-E517D9C8E3DF/libdl.so No LZMA support found for reading .gnu_debugdata section
warning: (x86_64) /home/runner/.lldb/module_cache/remote-android/.cache/896BBDB3-DFDF-EF7E-4E56-BCF87BE1517D/libnetd_client.so No LZMA support found for reading .gnu_debugdata section
warning: (x86_64) /home/runner/.lldb/module_cache/remote-android/.cache/1C26B06E-264B-4636-380B-BD604DD436FD/libc++.so No LZMA support found for reading .gnu_debugdata section
```
## Overview
* Install `liblzma-dev` and `lzma-dev` packages on Ubuntu systems
* Configure the lldb build with `-D LLDB_ENABLE_LZMA=On` to include LZMA support.

## Validation
Successful CI run: https://github.com/andrurogerz/ds2/actions/runs/13291337750