### PR TITLE
[gha] enable test case name logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -509,6 +509,7 @@ jobs:
               --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/linux-${{ matrix.arch }}.excluded \
               --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/ds2/linux-${{ matrix.arch }}.excluded \
               --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/non-debugserver-tests.excluded \
+              -v \
               ${{ matrix.test-subdirs }}
 
   test-android-x86:
@@ -663,4 +664,5 @@ jobs:
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/ds2/android-${{ matrix.llvm-arch }}.excluded
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/android-${{ matrix.llvm-arch }}.excluded
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/non-debugserver-tests.excluded
+            -v
             ${{ matrix.test-subdirs }}


### PR DESCRIPTION
Add the `-v` option when running `lldb-dotest` so that the name of each test case is logged prior to running the test.

Example:
```
472: test_debugger_interrupt_use_dbg (TestDebuggerInterruption.TestDebuggerInterruption.test_debugger_interrupt_use_dbg) ... ok
PASS: LLDB (/home/runner/work/ds2/ds2/BinaryCache/llvm/bin/clang-i686) :: test_debugger_interrupt_use_dbg (TestDebuggerInterruption.TestDebuggerInterruption.test_debugger_interrupt_use_dbg)
```

This logging will help to identify test cases that occasionally hang so we can disable them.

