### PR TITLE
git: ignore `/out/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Output Directories
 /build/
 /html/
+/out/
 
 # Generated Data
 /Definitions/RISCV32.json


### PR DESCRIPTION
This directory is referenced in the documentation as the default output
location. Ignore this location as a potential build tree.