### PR TITLE
build: bump CMake requirement to 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 ## PATENTS file in the same directory.
 ##
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.25)
 cmake_policy(SET CMP0054 NEW)
 
 project(DebugServer2


### PR DESCRIPTION
Bump the required CMake version to 3.25 as we are using the `LINUX` variable
which was introduced in 3.25. This ensures that we build properly on Linux by
preventing use of an older CMake where certain sources and checks may be
otherwise elided.