### PR TITLE
POSIX: provide compatibility for older Linux environments

### DIFF
--- a/Sources/Utils/POSIX/FaultHandler.cpp
+++ b/Sources/Utils/POSIX/FaultHandler.cpp
@@ -31,10 +31,10 @@ private:
   }
 
   void installCatcher() {
-#if defined(__APPLE__) || defined(__FreeBSD__)
-    long sz = SIGSTKSZ;
-#elif defined(__ANDROID__)
+#if defined(__ANDROID__)
     long sz = MINSIGSTKSZ;
+#elif defined(__APPLE__) || defined(__FreeBSD__) || !defined(_SC_SIGSTKSZ)
+    long sz = SIGSTKSZ;
 #else
     long sz = sysconf(_SC_SIGSTKSZ);
     if (sz == -1)


### PR DESCRIPTION
`_SC_SIGSTKSZ` was introduced in a semi-recent glibc version. Provide a fallback
for older glibc environments so that we can support a broader set of Linux
environments.