### PR TITLE
Headers: remove C++14 compatibility shim

### DIFF
--- a/Headers/DebugServer2/Base.h
+++ b/Headers/DebugServer2/Base.h
@@ -124,17 +124,10 @@ typename std::enable_if<
 }
 
 namespace ds2 {
-
-// We don't use C++14 (yet).
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args &&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-
-// This thing allows classes with protected constructors to call
-// make_protected_unique to construct a unique_ptr cleanly (which calls
-// make_unique internally). Without this, classes with protected constructors
-// cannot be make_unique'd.
+// Wrapper to allow classes with protected constructors to call
+// `make_protected_unique` to construct a `unique_ptr` cleanly (which calls
+// `make_unique` internally). Without this, classes with protected constructors
+// cannot be `make_unique`'d.
 template <typename T> struct make_unique_enabler {
   struct make_unique_enabler_helper : public T {
     template <typename... Args>
@@ -143,7 +136,7 @@ template <typename T> struct make_unique_enabler {
 
   template <typename... Args>
   static std::unique_ptr<T> make_protected_unique(Args... args) {
-    return ds2::make_unique<make_unique_enabler_helper>(
+    return std::make_unique<make_unique_enabler_helper>(
         std::forward<Args>(args)...);
   }
 };

--- a/Sources/Target/Common/ProcessBase.cpp
+++ b/Sources/Target/Common/ProcessBase.cpp
@@ -324,7 +324,7 @@ ErrorCode ProcessBase::afterResume() {
 
 SoftwareBreakpointManager *ProcessBase::softwareBreakpointManager() const {
   if (!_softwareBreakpointManager) {
-    _softwareBreakpointManager = ds2::make_unique<SoftwareBreakpointManager>(
+    _softwareBreakpointManager = std::make_unique<SoftwareBreakpointManager>(
         const_cast<ProcessBase *>(this));
   }
 
@@ -333,7 +333,7 @@ SoftwareBreakpointManager *ProcessBase::softwareBreakpointManager() const {
 
 HardwareBreakpointManager *ProcessBase::hardwareBreakpointManager() const {
   if (!_hardwareBreakpointManager) {
-    _hardwareBreakpointManager = ds2::make_unique<HardwareBreakpointManager>(
+    _hardwareBreakpointManager = std::make_unique<HardwareBreakpointManager>(
         const_cast<ProcessBase *>(this));
   }
 

--- a/Sources/Target/POSIX/Process.cpp
+++ b/Sources/Target/POSIX/Process.cpp
@@ -18,6 +18,7 @@
 #include <cerrno>
 #include <csignal>
 #include <cstring>
+#include <memory>
 
 #include <sys/mman.h>
 #include <sys/wait.h>
@@ -129,7 +130,7 @@ ds2::Target::Process *Process::Attach(ProcessId pid) {
   if (pid <= 0)
     return nullptr;
 
-  auto process = ds2::make_unique<Target::Process>();
+  auto process = std::make_unique<Target::Process>();
 
   if (process->ptrace().attach(pid) != kSuccess) {
     DS2LOG(Error, "ptrace attach failed: %s", strerror(errno));
@@ -145,7 +146,7 @@ ds2::Target::Process *Process::Attach(ProcessId pid) {
 }
 
 ds2::Target::Process *Process::Create(ProcessSpawner &spawner) {
-  auto process = ds2::make_unique<Target::Process>();
+  auto process = std::make_unique<Target::Process>();
 
   if (spawner.run([&process]() {
         // move debug targets to their own process group

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -533,7 +533,7 @@ ds2::Target::Process *Process::Create(ProcessSpawner &spawner) {
   DS2LOG(Debug, "created process %" PRIu64, (uint64_t)spawner.pid());
 
   struct MakeUniqueEnabler : public Process {};
-  auto process = ds2::make_unique<MakeUniqueEnabler>();
+  auto process = std::make_unique<MakeUniqueEnabler>();
 
   if (process->initialize(spawner.pid(), kFlagNewProcess) != kSuccess) {
     return nullptr;

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -83,7 +83,7 @@ static std::unique_ptr<Socket> CreateFDSocket(int fd) {
     DS2LOG(Error, "cannot use fd %d: refers to a terminal", fd);
   }
 
-  auto socket = ds2::make_unique<Socket>(fd);
+  auto socket = std::make_unique<Socket>(fd);
 
   return socket;
 }
@@ -95,7 +95,7 @@ static std::unique_ptr<Socket> CreateFDSocket(int fd) {
 static std::unique_ptr<Socket> CreateTCPSocket(std::string const &host,
                                                std::string const &port,
                                                bool reverse) {
-  auto socket = ds2::make_unique<Socket>();
+  auto socket = std::make_unique<Socket>();
 
   if (reverse) {
     if (!socket->connect(host, port)) {
@@ -136,7 +136,7 @@ static std::unique_ptr<Socket> CreateUNIXSocket(std::string const &path,
     DS2LOG(Fatal, "reverse connections not supported with UNIX sockets");
   }
 
-  auto socket = ds2::make_unique<Socket>();
+  auto socket = std::make_unique<Socket>();
 
   if (!socket->listen(path, abstract)) {
     DS2LOG(Fatal, "cannot listen on %s: %s", path.c_str(),
@@ -499,11 +499,11 @@ static int GdbserverMain(int argc, char **argv) {
   std::unique_ptr<DebugSessionImpl> impl;
 
   if (attachPid > 0)
-    impl = ds2::make_unique<DebugSessionImpl>(attachPid);
+    impl = std::make_unique<DebugSessionImpl>(attachPid);
   else if (args.size() > 0)
-    impl = ds2::make_unique<DebugSessionImpl>(args, env);
+    impl = std::make_unique<DebugSessionImpl>(args, env);
   else
-    impl = ds2::make_unique<DebugSessionImpl>();
+    impl = std::make_unique<DebugSessionImpl>();
 
   return RunDebugServer(channel.get(), impl.get());
 }
@@ -550,7 +550,7 @@ static int PlatformMain(int argc, char **argv) {
   do {
     std::unique_ptr<Socket> clientSocket = serverSocket->accept();
     auto platformClient =
-        ds2::make_unique<PlatformClient>(std::move(clientSocket));
+        std::make_unique<PlatformClient>(std::move(clientSocket));
 
     std::thread thread(
         [](std::unique_ptr<PlatformClient> client) {


### PR DESCRIPTION
We currently use C++17 as the C++ standard. Remove compatibility shims to enable
building with C++11.