### PR TITLE
[gha] fix lzma package install commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,8 +327,9 @@ jobs:
 
     steps:
       - name: Install LZMA libraries
-        run:
-          sudo apt install lzma-dev liblzma-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qq --no-install-recommends lzma-dev liblzma-dev
 
       - if: ${{ !contains(matrix.runner, 'arm') }}
         uses: seanmiddleditch/gha-setup-ninja@v5


### PR DESCRIPTION
A couple of minor fixes to address broken github action:
* Call `apt-get update` before installing lzma packages
* Update the lzma package install command to match other package install commands (use `apt-get` and quiet options) 