### PR TITLE
[cmake] update JSObjects CMake minimum version to 3.10

### DIFF
--- a/Tools/JSObjects/CMakeLists.txt
+++ b/Tools/JSObjects/CMakeLists.txt
@@ -8,7 +8,7 @@
 ## PATENTS file in the same directory.
 ##
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 
 project(JSObjects
   LANGUAGES C CXX)


### PR DESCRIPTION
Bump the min required CMake version for JSObjects to 3.10. This avoids errors and warnings when building with CMake versions >= 4.0 which no longer support syntax < version 3.5 and warn on < version 3.10.

I observed these failures a few time in nightly runs, but they are not consistent. It seems like some of the GitHub runners have newer CMake versions.

https://github.com/andrurogerz/ds2/actions/runs/14258245061/job/39964714091
https://github.com/andrurogerz/ds2/actions/runs/14235199194/job/39893148054
https://github.com/andrurogerz/ds2/actions/runs/14211762613/job/39820138528