### PR TITLE
docs: improve README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,58 @@
 # ds2
 
-ds2 is a debug server designed to be used with [LLDB](http://lldb.llvm.org/) to perform remote debugging of Linux, Android, FreeBSD, Windows targets.
+ds2 is a debug server designed to be used with [LLDB](http://lldb.llvm.org/) to
+perform remote debugging of Linux, Android, FreeBSD, Windows targets.
+
+### Platform Support
+
+There is varying support for different platforms. While not all the possible
+platforms are under CI coverage, DS2 has been known to run on the following
+platforms at various times.
+
+- [x] Anrdoid
+  - [x] ARM64
+  - [x] ARMv7
+  - [x] X64
+  - [x] X86
+
+- [x] Darwin
+  - [ ] ARM64
+  - [x] X64
+  - [x] X86
+
+- [x] FreeBSD
+  - [x] X64
+  - [x] X86
+
+- [x] Linux
+  - [x] ARM64
+  - [x] ARMv7
+  - [x] RISCV64
+  - [x] X64
+  - [x] X86
+
+- [x] MinGW
+  - [ ] ARM64
+  - [x] ARMv7
+  - [x] X64
+  - [x] X86
+
+- [-] Tizen
+  - [x] ARMv7
+  - [x] X86
+
+- [x] Windows
+  - [ ] ARM64
+  - [x] ARMv7
+  - [x] X64
+  - [x] X86
+
+### Contributing
+
+Patches are welcome to fix issues on existing platforms as well as to improve
+coverage of existing or new platforms. For CI coverage, patches to increase
+coverage under GitHub Actions or to migrate coverage from CircleCI are also
+welcome.
 
 ### Documentation
 - [Android](Documentation/Android.md)
@@ -18,3 +70,6 @@ regsgen2, a tool used to generate register definitions is also licensed under
 the University of Illinois/NCSA Open Source License and uses a json library
 licensed under the Boost Software License. A complete copy of the latter can be
 found in `Tools/libjson/LICENSE_1_0.txt`.
+
+Note that neither regsgen2 nor libjson are part of the ds2 distribution itself,
+but rather are used to generate code that is included in ds2.


### PR DESCRIPTION
Add a flat list of supported debugging platforms. This should aide users looking to see if a particular platform is supported by DS2.

Clarify that regsgen2 and libjson are not distributed as part of the DS2 distribution.

Add a small blurb indicating that contributions are welcome.