### PR TITLE
Target: implement the Darwin ARM64 support to complete the port

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,9 +214,12 @@ jobs:
             ${{ github.workspace }}/BinaryCache/ds2/ds2.exe
 
   macos:
-    # Build on macos-26-intel, which is x86_64-based, until Darwin
-    # on ARM support is implemented.
-    runs-on: macos-26-intel
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        processor: [ arm64, x86_64 ]
 
     steps:
       - uses: actions/checkout@v7
@@ -226,6 +229,7 @@ jobs:
           cmake -B ${{ github.workspace }}/BinaryCache/ds2                      \
                 -C ${{ github.workspace }}/cmake/caches/ClangWarnings.cmake     \
                 -D CMAKE_BUILD_TYPE=Release                                     \
+                -D CMAKE_OSX_ARCHITECTURES="${{ matrix.processor }}"           \
                 -G Ninja                                                        \
                 -S ${{ github.workspace }}
       - name: Build
@@ -233,7 +237,7 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: macOS-x86_64-ds2
+          name: macOS-${{ matrix.processor }}-ds2
           path: |
             ${{ github.workspace }}/BinaryCache/ds2/ds2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,19 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   endif()
 endif()
 
+if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+  list(LENGTH CMAKE_OSX_ARCHITECTURES DS2_OSX_ARCHITECTURE_COUNT)
+  if(DS2_OSX_ARCHITECTURE_COUNT EQUAL 1)
+    # On Apple platforms, CMAKE_SYSTEM_PROCESSOR reflects the host running
+    # the configure, not the architecture being targeted -- it is never
+    # derived from CMAKE_OSX_ARCHITECTURES. A single-arch cross build (e.g.
+    # -D CMAKE_OSX_ARCHITECTURES=x86_64 on an arm64 host) would otherwise
+    # select the wrong DS2_ARCHITECTURE below and pick the host's source set
+    # while Clang actually emits code for the requested architecture.
+    set(CMAKE_SYSTEM_PROCESSOR "${CMAKE_OSX_ARCHITECTURES}")
+  endif()
+endif()
+
 if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "ARM64" OR
    CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AArch64|ARM64|arm64")
   set(DS2_ARCHITECTURE ARM64)
@@ -231,7 +244,7 @@ if(DS2_ARCHITECTURE MATCHES "ARM|ARM64")
   set_source_files_properties(
     Sources/Architecture/ARM/ThumbBranchInfo.cpp
     PROPERTIES
-      COMPILE_OPTIONS $<$<CXX_COMPILER_ID:Clang>:-Wno-error=comma>)
+      COMPILE_OPTIONS $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-error=comma>)
 
   target_sources(ds2 PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/Headers/DebugServer2/Architecture/ARM/RegistersDescriptors.h

--- a/Headers/DebugServer2/Host/Darwin/Mach.h
+++ b/Headers/DebugServer2/Host/Darwin/Mach.h
@@ -33,6 +33,15 @@ public:
                         size_t *nwritten = nullptr);
 
 public:
+  // Flushes the instruction cache (and unifies it with the data cache) for
+  // `address`..+`length` in `ptid`'s address space. Needed after writing
+  // executable code into another process on architectures where
+  // instruction fetches aren't automatically coherent with data writes
+  // (e.g. AArch64 -- unlike x86, which guarantees this in hardware).
+  ErrorCode flushInstructionCache(ProcessThreadId const &ptid,
+                                  Address const &address, size_t length);
+
+public:
   ErrorCode readCPUState(ProcessThreadId const &ptid, ProcessInfo const &info,
                          Architecture::CPUState &state);
   ErrorCode writeCPUState(ProcessThreadId const &ptid, ProcessInfo const &info,
@@ -46,6 +55,12 @@ public:
                  int signal = 0, Address const &address = Address());
   ErrorCode resume(ProcessThreadId const &ptid, ProcessInfo const &pinfo,
                    int signal = 0, Address const &address = Address());
+
+public:
+  // AArch64-only: arms/disarms the MDSCR_EL1.SS hardware single-step trap.
+  // Implemented in MachARM64.cpp; unused (and undefined) on other
+  // architectures, which single-step through other means.
+  ErrorCode setSingleStep(ProcessThreadId const &ptid, bool enable);
 
 public:
   ErrorCode getProcessDylbInfo(ProcessId pid, Address &address);

--- a/Headers/DebugServer2/Target/Darwin/Process.h
+++ b/Headers/DebugServer2/Target/Darwin/Process.h
@@ -39,6 +39,13 @@ public:
                            uint64_t *address) override;
   ErrorCode deallocateMemory(uint64_t address, size_t size) override;
 
+protected:
+  // Injects `code` at the current thread's PC, executes it to completion,
+  // and restores the original code/registers. Darwin's ptrace cannot read
+  // or write registers/memory (see Host::Darwin::PTrace), so this goes
+  // through Mach for state/memory access instead of POSIX::PTrace::execute.
+  ErrorCode executeCode(ByteVector const &code, uint64_t &result);
+
 public:
   ErrorCode readString(Address const &address, std::string &str, size_t length,
                        size_t *count = nullptr) override;

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ platforms at various times.
 
 - [x] ARM64
   - [x] Android
-  - [ ] Darwin
+  - [x] Darwin
   - [x] Linux
   - [x] MinGW
   - [ ] Windows

--- a/Sources/Host/Darwin/ARM64/MachARM64.cpp
+++ b/Sources/Host/Darwin/ARM64/MachARM64.cpp
@@ -126,6 +126,40 @@ ErrorCode Mach::writeCPUState(const ProcessThreadId &tid, const ProcessInfo &inf
   return result == KERN_SUCCESS ? kSuccess : kErrorInvalidArgument;
 }
 
+ErrorCode Mach::setSingleStep(const ProcessThreadId &tid, bool enable) {
+  if (!tid.valid())
+    return kErrorInvalidArgument;
+
+  thread_t thread = getMachThread(tid);
+  if (thread == THREAD_NULL)
+    return kErrorProcessNotFound;
+
+  mach_msg_type_number_t state_count = ARM_DEBUG_STATE64_COUNT;
+  arm_debug_state64_t debug_state;
+  kern_return_t result;
+
+  result = thread_get_state(thread, ARM_DEBUG_STATE64,
+                            reinterpret_cast<thread_state_t>(&debug_state),
+                            &state_count);
+  if (result != KERN_SUCCESS)
+    return kErrorInvalidArgument;
+
+  // MDSCR_EL1 bit 0 (SS) arms the hardware single-step trap. It must be
+  // paired with PSTATE.SS (CPSR bit 21, set on the GP thread state by the
+  // caller) for the very next instruction to actually trap; the CPU clears
+  // PSTATE.SS itself once the trap fires.
+  if (enable) {
+    debug_state.__mdscr_el1 |= 1ULL;
+  } else {
+    debug_state.__mdscr_el1 &= ~1ULL;
+  }
+
+  result = thread_set_state(thread, ARM_DEBUG_STATE64,
+                            reinterpret_cast<thread_state_t>(&debug_state),
+                            ARM_DEBUG_STATE64_COUNT);
+  return result == KERN_SUCCESS ? kSuccess : kErrorInvalidArgument;
+}
+
 }
 }
 }

--- a/Sources/Host/Darwin/Mach.cpp
+++ b/Sources/Host/Darwin/Mach.cpp
@@ -131,6 +131,23 @@ ErrorCode Mach::writeMemory(ProcessThreadId const &ptid, Address const &address,
   return error;
 }
 
+ErrorCode Mach::flushInstructionCache(ProcessThreadId const &ptid,
+                                      Address const &address, size_t length) {
+  task_t task = getMachTask(ptid.pid);
+  if (task == TASK_NULL) {
+    return kErrorProcessNotFound;
+  }
+
+  vm_machine_attribute_val_t value = MATTR_VAL_CACHE_FLUSH;
+  kern_return_t kret = mach_vm_machine_attribute(
+      task, address.value(), length, MATTR_CACHE, &value);
+  if (kret != KERN_SUCCESS) {
+    return kErrorUnknown;
+  }
+
+  return kSuccess;
+}
+
 ErrorCode Mach::suspend(ProcessThreadId const &ptid) {
   thread_t thread = getMachThread(ptid);
   if (thread == THREAD_NULL) {

--- a/Sources/Target/Darwin/ARM64/ProcessARM64.cpp
+++ b/Sources/Target/Darwin/ARM64/ProcessARM64.cpp
@@ -1,14 +1,63 @@
-//
-// Copyright (c) 2014-present, Saleem Abdulrasool <compnerd@compnerd.org>
-// All rights reserved.
-//
-// This source code is licensed under the University of Illinois/NCSA Open
-// Source License found in the LICENSE file in the root directory of this
-// source tree. An additional grant of patent rights can be found in the
-// PATENTS file in the same directory.
-//
+// Copyright 2024-2025 Saleem Abdulrasool <compnerd@compnerd.org>
 
 #include "DebugServer2/Target/Process.h"
+
+#include <cmath>
+
+#include <stddef.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+
+namespace {
+template <typename T>
+inline void InsertBytes(ds2::ByteVector &bytes, T value) {
+  uint8_t *data = reinterpret_cast<uint8_t *>(&value);
+  bytes.insert(std::end(bytes), data, data + sizeof(T));
+}
+
+namespace syscalls {
+inline void mmap(size_t size, int protection, ds2::ByteVector &code) {
+  DS2ASSERT(std::log2(MAP_ANON | MAP_PRIVATE) <= 16);
+  DS2ASSERT(std::log2(SYS_mmap) <= 16);
+  DS2ASSERT(std::log2(protection) <= 16);
+
+  for (uint32_t instruction: {
+            static_cast<uint32_t>(0xd2800000),                                  // mov x0, 0
+            static_cast<uint32_t>(0x58000101),                                  // ldr x1, .Lsize
+            static_cast<uint32_t>(0xd2800002 | protection << 5),                // mov x2, protection
+            static_cast<uint32_t>(0xd2800003 | (MAP_ANON | MAP_PRIVATE) << 5),  // mov x3, MAP_ANON | MAP_PRIVATE
+            static_cast<uint32_t>(0x92800004),                                  // mov x4, -1
+            static_cast<uint32_t>(0xd2800005),                                  // mov x5, 0
+            static_cast<uint32_t>(0xd2800010 | SYS_mmap << 5),                  // mov x16, =SYS_mmap
+            static_cast<uint32_t>(0xd4000001),                                  // svc 0
+            static_cast<uint32_t>(0xd43e0000),                                  // brk #0xf000
+                                                                                // .Lsize:
+                                                                                //    .quad size
+      })
+    InsertBytes(code, instruction);
+  InsertBytes(code, size);
+}
+
+inline void munmap(uintptr_t address, size_t size, ds2::ByteVector &code) {
+  DS2ASSERT(std::log2(SYS_munmap) <= 16);
+
+  for (uint32_t instruction: {
+            static_cast<uint32_t>(0x580000a0),                                  // ldr x0, .Laddress
+            static_cast<uint32_t>(0x580000c1),                                  // ldr x1, .Lsize
+            static_cast<uint32_t>(0xd2800010 | SYS_munmap << 5),                // mov x16, =SYS_munmap
+            static_cast<uint32_t>(0xd4000001),                                  // svc 0
+            static_cast<uint32_t>(0xd43e0000),                                  // brk #0xf000
+                                                                                // .Laddress:
+                                                                                //    .quad address
+                                                                                // .Lsize:
+                                                                                //    .quad size
+      })
+    InsertBytes(code, instruction);
+  InsertBytes(code, address);
+  InsertBytes(code, size);
+}
+}
+}
 
 namespace ds2 {
 namespace Target {
@@ -18,12 +67,33 @@ ErrorCode Process::allocateMemory(size_t size, uint32_t protection,
   if (address == nullptr || size == 0)
     return kErrorInvalidArgument;
 
-  *address = 0;
-  return kErrorUnsupported;
+  ByteVector code;
+  syscalls::mmap(size, convertMemoryProtectionFromPOSIX(protection), code);
+
+  ErrorCode error = executeCode(code, *address);
+  if (error != kSuccess)
+    return error;
+
+  if (*address == reinterpret_cast<uint64_t>(MAP_FAILED))
+    return kErrorNoMemory;
+  return kSuccess;
 }
 
 ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
-  return kErrorUnsupported;
+  if (size == 0)
+    return kErrorInvalidArgument;
+
+  ByteVector code;
+  syscalls::munmap(address, size, code);
+
+  uint64_t result = 0;
+  ErrorCode error = executeCode(code, result);
+  if (error != kSuccess)
+    return error;
+
+  if (static_cast<int64_t>(result) < 0)
+    return kErrorInvalidArgument;
+  return kSuccess;
 }
 }
 }

--- a/Sources/Target/Darwin/ARM64/ThreadARM64.cpp
+++ b/Sources/Target/Darwin/ARM64/ThreadARM64.cpp
@@ -10,16 +10,50 @@
 
 #include "DebugServer2/Target/Darwin/Thread.h"
 #include "DebugServer2/Architecture/CPUState.h"
+#include "DebugServer2/Target/Process.h"
 
 namespace ds2 {
 namespace Target {
 namespace Darwin {
+
+namespace {
+// PSTATE.SS, per the ARMv8 architecture reference manual.
+constexpr uint64_t kPSTATE_SS = 1ULL << 21;
+}
+
 ErrorCode Thread::step(int signal, Address const &address) {
-  return kErrorUnsupported;
+  ErrorCode error = modifyRegisters([](Architecture::CPUState &state) {
+    state.state64.gp.cpsr |= kPSTATE_SS;
+  });
+  if (error != kSuccess)
+    return error;
+
+  error = process()->mach().setSingleStep(
+      ProcessThreadId(process()->pid(), tid()), true);
+  if (error != kSuccess)
+    return error;
+
+  error = resume(signal, address);
+  if (error != kSuccess)
+    return error;
+
+  // resume() sets _state to kRunning; Process::wait()'s ignored-signal path
+  // checks kStepped to decide whether to re-issue a step or a plain resume
+  // if this step is interrupted before it completes, so this has to be set
+  // after resume(), not folded into it.
+  _state = kStepped;
+  return kSuccess;
 }
 
 ErrorCode Thread::afterResume() {
-  return kErrorUnsupported;
+  ErrorCode error = modifyRegisters([](Architecture::CPUState &state) {
+    state.state64.gp.cpsr &= ~kPSTATE_SS;
+  });
+  if (error != kSuccess)
+    return error;
+
+  return process()->mach().setSingleStep(
+      ProcessThreadId(process()->pid(), tid()), false);
 }
 }
 }

--- a/Sources/Target/Darwin/Process.cpp
+++ b/Sources/Target/Darwin/Process.cpp
@@ -321,6 +321,91 @@ ErrorCode Process::writeMemory(Address const &address, void const *data,
                             count);
 }
 
+ErrorCode Process::executeCode(ByteVector const &code, uint64_t &result) {
+  if (_currentThread == nullptr)
+    return kErrorProcessNotFound;
+
+  ProcessThreadId ptid(_pid, _currentThread->tid());
+  // PTrace::resume/wait/kill on Darwin only accept a process-only ptid
+  // (tid <= kAnyThreadId): POSIX::PTrace::wait rejects anything else before
+  // ever calling waitpid, and Darwin::PTrace::kill hits a fatal DS2BUG for
+  // anything else. Mach calls below need the real thread id; these don't.
+  ProcessThreadId pptid(_pid);
+  ProcessInfo info;
+  CHK(getInfo(info));
+
+  Architecture::CPUState savedState, resultState;
+  CHK(mach().readCPUState(ptid, info, savedState));
+
+  ByteVector savedCode(code.size());
+  CHK(mach().readMemory(ptid, savedState.pc(), savedCode.data(),
+                        savedCode.size()));
+
+  ErrorCode restoreError;
+  ErrorCode error = mach().writeMemory(ptid, savedState.pc(), code.data(),
+                                       code.size());
+#if defined(ARCH_ARM64)
+  // AArch64 doesn't keep instruction fetches coherent with data writes the
+  // way x86 does; without this, the thread can fetch whatever was
+  // previously cached at this address instead of the code just written.
+  if (error == kSuccess)
+    error = mach().flushInstructionCache(ptid, savedState.pc(), code.size());
+#endif
+  if (error != kSuccess)
+    goto fail;
+
+  error = ptrace().resume(pptid, info);
+  if (error == kSuccess)
+    error = ptrace().wait(pptid);
+
+  if (error == kSuccess) {
+    error = mach().readCPUState(ptid, info, resultState);
+    if (error == kSuccess) {
+      result = resultState.retval();
+
+      // Darwin's raw syscall ABI reports failure via the carry flag, with
+      // the return register left holding a positive errno rather than
+      // POSIX's -1/negative-errno convention (see arm_prepare_u64_syscall_
+      // return in XNU); synthesize the -1 sentinel callers already check
+      // for (MAP_FAILED, or plain `< 0`) so a failed injected syscall
+      // isn't mistaken for success at address/result `errno`.
+#if defined(ARCH_ARM64)
+      if (resultState.state64.gp.cpsr & (1ULL << 29))
+        result = static_cast<uint64_t>(-1);
+#elif defined(ARCH_X86_64)
+      if (resultState.state64.gp.eflags & 1u)
+        result = static_cast<uint64_t>(-1);
+#endif
+    }
+  }
+
+  // Always try to restore the original code/registers, but don't let a
+  // successful restore mask a failure from actually running the injected
+  // code above -- `error` (and `result`) from that point still stand.
+  restoreError = mach().writeMemory(ptid, savedState.pc(), savedCode.data(),
+                                    savedCode.size());
+#if defined(ARCH_ARM64)
+  // Otherwise the thread could re-execute the stale injected stub instead
+  // of the restored original code once resumed.
+  if (restoreError == kSuccess)
+    restoreError = mach().flushInstructionCache(ptid, savedState.pc(),
+                                                savedCode.size());
+#endif
+  if (restoreError == kSuccess)
+    restoreError = mach().writeCPUState(ptid, info, savedState);
+
+  if (restoreError != kSuccess) {
+    error = restoreError;
+    goto fail;
+  }
+
+  return error;
+
+fail:
+  ptrace().kill(pptid, SIGKILL); // we can't really do much at this point :(
+  return error;
+}
+
 ErrorCode Process::afterResume() {
   // We are calling the Thread's afterResume from here, but it might make sense
   // to have this known by ThreadBase and call it from ProcessBase::resume.

--- a/Sources/Target/Darwin/X86_64/ProcessX86_64.cpp
+++ b/Sources/Target/Darwin/X86_64/ProcessX86_64.cpp
@@ -66,17 +66,11 @@ ErrorCode Process::allocateMemory(size_t size, uint32_t protection,
     return kErrorInvalidArgument;
   }
 
-  ProcessInfo info;
-  ErrorCode error = getInfo(info);
-  if (error != kSuccess) {
-    return error;
-  }
-
   ByteVector codestr;
   PrepareMmapCode(size, convertMemoryProtectionToPOSIX(protection), codestr);
 
   // Code inject and execute
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), *address);
+  ErrorCode error = executeCode(codestr, *address);
   if (error != kSuccess) {
     return error;
   }
@@ -92,11 +86,6 @@ ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
   if (size == 0)
     return kErrorInvalidArgument;
 
-  ProcessInfo info;
-  ErrorCode error = getInfo(info);
-  if (error != kSuccess)
-    return error;
-
   ByteVector codestr;
   PrepareMunmapCode(address, size, codestr);
 
@@ -104,7 +93,7 @@ ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
   // Code inject and execute
   //
   uint64_t result = 0;
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), result);
+  ErrorCode error = executeCode(codestr, result);
   if (error != kSuccess)
     return error;
 

--- a/Sources/Target/Darwin/X86_64/ThreadX86_64.cpp
+++ b/Sources/Target/Darwin/X86_64/ThreadX86_64.cpp
@@ -25,7 +25,18 @@ ErrorCode Thread::step(int signal, Address const &address) {
   if (error != kSuccess) {
     return error;
   }
-  return resume(signal, address);
+
+  error = resume(signal, address);
+  if (error != kSuccess) {
+    return error;
+  }
+
+  // resume() sets _state to kRunning; Process::wait()'s ignored-signal path
+  // checks kStepped to decide whether to re-issue a step or a plain resume
+  // if this step is interrupted before it completes, so this has to be set
+  // after resume(), not folded into it.
+  _state = kStepped;
+  return kSuccess;
 }
 
 ErrorCode Thread::afterResume() {


### PR DESCRIPTION
This implements the necessary ARM64 specific logic for mmap and munmap syscalls to be able to allocate and deallocate memory in the inferior. This gives us a complete implementation for the Darwin ARM64 target.