### PR TITLE
GHA: bump to VS 2026

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           cmake -B ${{ github.workspace }}/BinaryCache/RegsGen2 `
                 -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake `
-                -G "Visual Studio 17 2022" `
+                -G "Visual Studio 18 2026" `
                 -A x64 `
                 -S ${{ github.workspace }}/Tools/RegsGen2
       - name: Build
@@ -65,7 +65,7 @@ jobs:
         run: |
           cmake -B ${{ github.workspace }}/BinaryCache/ds2 `
                 -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake `
-                -G "Visual Studio 17 2022" `
+                -G "Visual Studio 18 2026" `
                 -A ${{ matrix.arch }} `
                 -D DS2_REGSGEN2=${{ github.workspace }}/BinaryCache/RegsGen2/Release/regsgen2.exe `
                 -S ${{ github.workspace }}


### PR DESCRIPTION
The runner images have been updated to VS2026, update the generator name to mirror that.