### PR TITLE
build: modernise CMake usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,16 +9,12 @@
 ##
 
 cmake_minimum_required(VERSION 3.25)
-cmake_policy(SET CMP0054 NEW)
 
 project(DebugServer2
   LANGUAGES C CXX)
 
 set(DS2_PROGRAM_PREFIX "" CACHE STRING "Prefix to apply to the ds2 binary")
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_EXTENSIONS NO)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(WIN32)
@@ -96,43 +92,42 @@ if(DS2_REGSGEN2)
     IMPORTED_LOCATION ${DS2_REGSGEN2})
 else()
   if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
-    set(CMAKE_HOST_EXECUTABLE_SUFFIX .exe)
+    set(DS2_REGSGEN2_HOST_EXECUTABLE_SUFFIX .exe)
   else()
-    set(CMAKE_HOST_EXECUTABLE_SUFFIX)
+    set(DS2_REGSGEN2_HOST_EXECUTABLE_SUFFIX)
   endif()
 
   get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
   if(GENERATOR_IS_MULTI_CONFIG)
-    set(RegsGen2_RELATIVE_PATH Release/regsgen2${CMAKE_HOST_EXECUTABLE_SUFFIX})
+    set(DS2_REGSGEN2_RELATIVE_PATH Release/regsgen2${DS2_REGSGEN2_HOST_EXECUTABLE_SUFFIX})
   else()
-    set(RegsGen2_RELATIVE_PATH regsgen2${CMAKE_HOST_EXECUTABLE_SUFFIX})
+    set(DS2_REGSGEN2_RELATIVE_PATH regsgen2${DS2_REGSGEN2_HOST_EXECUTABLE_SUFFIX})
   endif()
 
   include(ExternalProject)
+  set(DS2_REGSGEN2_CMAKE_ARGS
+    -DCMAKE_BUILD_TYPE:STRING=Release
+    -DCMAKE_MAKE_PROGRAM:STRING=${CMAKE_MAKE_PROGRAM}
+    -DCMAKE_SYSTEM_NAME:STRING=${CMAKE_HOST_SYSTEM_NAME}
+    -DCMAKE_SYSTEM_PROCESSOR:STRING=${CMAKE_HOST_SYSTEM_PROCESSOR})
   if(FLEX_EXECUTABLE)
-    set(_FLEX_EXECUTABLE_ARG "-DFLEX_EXECUTABLE=${FLEX_EXECUTABLE}")
+    list(APPEND DS2_REGSGEN2_CMAKE_ARGS -DFLEX_EXECUTABLE=${FLEX_EXECUTABLE})
   endif()
   if(BISON_EXECUTABLE)
-    set(_BISON_EXECUTABLE_ARG "-DBISON_EXECUTABLE=${BISON_EXECUTABLE}")
+    list(APPEND DS2_REGSGEN2_CMAKE_ARGS -DBISON_EXECUTABLE=${BISON_EXECUTABLE})
   endif()
   ExternalProject_Add(RegsGen2
     SOURCE_DIR ${PROJECT_SOURCE_DIR}/Tools/RegsGen2
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/RegsGen2
-    CMAKE_ARGS
-      -DCMAKE_BUILD_TYPE:STRING=Release
-      -DCMAKE_MAKE_PROGRAM:STRING=${CMAKE_MAKE_PROGRAM}
-      -DCMAKE_SYSTEM_NAME:STRING=${CMAKE_HOST_SYSTEM_NAME}
-      -DCMAKE_SYSTEM_PROCESSOR:STRING=${CMAKE_HOST_SYSTEM_PROCESSOR}
-      ${_FLEX_EXECUTABLE_ARG}
-      ${_BISON_EXECUTABLE_ARG}
+    CMAKE_ARGS ${DS2_REGSGEN2_CMAKE_ARGS}
     BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
     INSTALL_COMMAND ""
-    BUILD_BYPRODUCTS <BINARY_DIR>/${RegsGen2_RELATIVE_PATH})
+    BUILD_BYPRODUCTS <BINARY_DIR>/${DS2_REGSGEN2_RELATIVE_PATH})
   ExternalProject_Get_Property(RegsGen2 BINARY_DIR)
 
   add_executable(RegsGen2::RegsGen2 IMPORTED)
   set_target_properties(RegsGen2::RegsGen2 PROPERTIES
-    IMPORTED_LOCATION ${BINARY_DIR}/${RegsGen2_RELATIVE_PATH})
+    IMPORTED_LOCATION ${BINARY_DIR}/${DS2_REGSGEN2_RELATIVE_PATH})
   add_dependencies(RegsGen2::RegsGen2 RegsGen2)
 endif()
 
@@ -149,34 +144,32 @@ else()
   set(RegsGenOS $<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
 endif()
 
+function(ds2_regsgen2_generate ARCH MODE OUTPUT INCLUDE)
+  add_custom_command(OUTPUT
+      ${OUTPUT}
+    COMMAND
+      $<TARGET_FILE:RegsGen2::RegsGen2>
+        -a ${RegsGenOS}
+        -I ${INCLUDE}
+        ${MODE} -o ${OUTPUT}
+        -f "${PROJECT_SOURCE_DIR}/Definitions/${ARCH}.json"
+    DEPENDS
+      Definitions/${ARCH}.json
+      RegsGen2::RegsGen2)
+endfunction()
+
 foreach(ARCH ARM ARM64 RISCV32 RISCV64 RISCV128 X86 X86_64)
   set(ArchHeadersDir ${CMAKE_CURRENT_BINARY_DIR}/Headers/DebugServer2/Architecture/${ARCH})
   file(MAKE_DIRECTORY ${ArchHeadersDir})
-  add_custom_command(OUTPUT
-      ${ArchHeadersDir}/RegistersDescriptors.h
-    COMMAND
-      $<TARGET_FILE:RegsGen2::RegsGen2>
-        -a ${RegsGenOS}
-        -I DebugServer2/Architecture/RegisterLayout.h
-        -h -o ${ArchHeadersDir}/RegistersDescriptors.h
-        -f "${PROJECT_SOURCE_DIR}/Definitions/${ARCH}.json"
-    DEPENDS
-      Definitions/${ARCH}.json
-      RegsGen2::RegsGen2)
+  ds2_regsgen2_generate(${ARCH} -h
+    ${ArchHeadersDir}/RegistersDescriptors.h
+    DebugServer2/Architecture/RegisterLayout.h)
 
   set(ArchSourcesDir ${CMAKE_CURRENT_BINARY_DIR}/Sources/Architecture/${ARCH})
   file(MAKE_DIRECTORY ${ArchSourcesDir})
-  add_custom_command(OUTPUT
-      ${ArchSourcesDir}/RegistersDescriptors.cpp
-    COMMAND
-      $<TARGET_FILE:RegsGen2::RegsGen2>
-        -a ${RegsGenOS}
-        -I DebugServer2/Architecture/${ARCH}/RegistersDescriptors.h
-        -c -o ${ArchSourcesDir}/RegistersDescriptors.cpp
-        -f "${PROJECT_SOURCE_DIR}/Definitions/${ARCH}.json"
-    DEPENDS
-      Definitions/${ARCH}.json
-      RegsGen2::RegsGen2)
+  ds2_regsgen2_generate(${ARCH} -c
+    ${ArchSourcesDir}/RegistersDescriptors.cpp
+    DebugServer2/Architecture/${ARCH}/RegistersDescriptors.h)
 endforeach()
 
 add_executable(ds2
@@ -215,6 +208,10 @@ add_executable(ds2
   Sources/Utils/Log.cpp
   Sources/Utils/OptParse.cpp
   Sources/Utils/Stringify.cpp)
+set_target_properties(ds2 PROPERTIES
+  CXX_STANDARD 17
+  CXX_EXTENSIONS NO
+  CXX_STANDARD_REQUIRED YES)
 
 # Architecture Sources
 if(DS2_ARCHITECTURE MATCHES "ARM|ARM64")
@@ -401,7 +398,7 @@ elseif(WIN32)
       SetThreadContext TerminateThread VirtualAllocEx VirtualFreeEx
       VirtualQueryEx WaitForDebugEventEx WriteProcessMemory)
     CHECK_FUNCTION_EXISTS(${FUNC} HAVE_${FUNC})
-    if (HAVE_${CHECK})
+    if (HAVE_${FUNC})
       target_compile_definitions(ds2 PRIVATE HAVE_${FUNC})
     endif ()
   endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,13 +453,17 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   endif()
 endif()
 
-include(FindThreads)
+find_package(Threads REQUIRED)
 if (STATIC AND DEFINED CMAKE_THREAD_LIBS_INIT AND
     (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+  # $<LINK_LIBRARY:WHOLE_ARCHIVE,...> ignores the feature for INTERFACE
+  # libraries, which is what Threads::Threads is on platforms where
+  # CMAKE_THREAD_LIBS_INIT resolves to a real pthread archive (e.g. Tizen).
+  # Apply the whole-archive wrapping to the raw libraries directly instead.
   target_link_options(ds2 PRIVATE
     -Wl,--whole-archive ${CMAKE_THREAD_LIBS_INIT} -Wl,--no-whole-archive)
 else ()
-  target_link_libraries(ds2 PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(ds2 PRIVATE Threads::Threads)
 endif ()
 
 install(TARGETS ds2 DESTINATION bin)

--- a/Tools/JSObjects/CMakeLists.txt
+++ b/Tools/JSObjects/CMakeLists.txt
@@ -8,23 +8,15 @@
 ## PATENTS file in the same directory.
 ##
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.25)
 
 project(JSObjects
   LANGUAGES C CXX)
 
-set(CMAKE_C_STANDARD 99)
-set(CMAKE_C_EXTENSIONS NO)
-set(CMAKE_C_STANDARD_REQUIRED YES)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS NO)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 
-find_package(BISON)
-find_package(FLEX)
+find_package(BISON REQUIRED)
+find_package(FLEX REQUIRED)
 
 FLEX_TARGET(JSON_SCANNER
             ${JSObjects_SOURCE_DIR}/Sources/libjson/tokenizer.l
@@ -48,6 +40,13 @@ target_include_directories(jsobjects PUBLIC
 target_include_directories(jsobjects PRIVATE
     ${JSObjects_SOURCE_DIR}/Sources/libjson
     ${JSObjects_BINARY_DIR})
+set_target_properties(jsobjects PROPERTIES
+    C_STANDARD 99
+    C_EXTENSIONS NO
+    C_STANDARD_REQUIRED YES
+    CXX_STANDARD 11
+    CXX_EXTENSIONS NO
+    CXX_STANDARD_REQUIRED YES)
 
 if("${BSD}" STREQUAL "FreeBSD")
   target_compile_definitions(jsobjects PRIVATE

--- a/Tools/RegsGen2/CMakeLists.txt
+++ b/Tools/RegsGen2/CMakeLists.txt
@@ -8,14 +8,10 @@
 ## PATENTS file in the same directory.
 ##
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.25)
 
 project(RegsGen2
   LANGUAGES C CXX)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_EXTENSIONS NO)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 add_subdirectory(../JSObjects "${CMAKE_CURRENT_BINARY_DIR}/JSObjects")
 
@@ -31,5 +27,9 @@ add_executable(regsgen2
   RegisterSet.cpp
   RegisterTemplate.cpp
   main.cpp)
+set_target_properties(regsgen2 PROPERTIES
+  CXX_STANDARD 17
+  CXX_EXTENSIONS NO
+  CXX_STANDARD_REQUIRED YES)
 target_link_libraries(regsgen2 PRIVATE
   getopt jsobjects)


### PR DESCRIPTION
This pull request updates the CMake configuration for the main project and its tools to improve consistency, modernize CMake usage, and refactor build logic. Key changes include updating CMake minimum versions, centralizing language standard settings, requiring dependencies, and refactoring custom command generation for better maintainability.

**CMake Modernization and Consistency**

* Updated `cmake_minimum_required` to 3.25 in all CMake files and removed redundant or scattered language standard settings, replacing them with `set_target_properties` for each executable or library (`ds2`, `jsobjects`, `regsgen2`). [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL12-L21) [[2]](diffhunk://#diff-be449ec93f6b05b37f4c56295997439fe216501dbb77f647f7f46dc3bfb64a16L11-R19) [[3]](diffhunk://#diff-20c9133b281d4877e7aceeda1bd03e11690b1897cd68533fed98364cbce417b6L11-L19) [[4]](diffhunk://#diff-20c9133b281d4877e7aceeda1bd03e11690b1897cd68533fed98364cbce417b6R30-R33) [[5]](diffhunk://#diff-be449ec93f6b05b37f4c56295997439fe216501dbb77f647f7f46dc3bfb64a16R43-R49) [[6]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR211-R214)

**Dependency Management Improvements**

* Changed `find_package` for `BISON` and `FLEX` to be `REQUIRED` in `Tools/JSObjects/CMakeLists.txt`, ensuring build fails early if dependencies are missing.
* Updated thread library handling to use `find_package(Threads REQUIRED)` and modern CMake linking (`Threads::Threads`), replacing legacy `FindThreads` and manual linker flags.

**Build Logic Refactoring**

* Refactored the RegsGen2 build logic: replaced scattered variables with consistent naming, centralized CMake argument handling, and encapsulated custom command logic in a new function `ds2_regsgen2_generate` for generating architecture-specific files. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL99-R130) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL152-R172)

**Bug Fixes and Minor Cleanups**

* Fixed a bug in the Windows function check loop by using the correct variable (`FUNC`) instead of an undefined one (`CHECK`).

These changes improve the maintainability, portability, and reliability of the build system across all project components.