### PR TITLE
JSObjects: fix UB default argument in JSString constructor

### DIFF
--- a/Tools/JSObjects/Headers/JSObjects/JSObjects.h
+++ b/Tools/JSObjects/Headers/JSObjects/JSObjects.h
@@ -172,7 +172,7 @@ private:
   std::string _value;
 
 public:
-  JSString(std::string const &value = nullptr) : _value(value) {}
+  JSString(std::string const &value = std::string()) : _value(value) {}
 
   inline std::string const &value() const { return _value; }
 


### PR DESCRIPTION
JSString(std::string const &value = nullptr) implicitly constructs a std::string from a null const char*, which is undefined behavior. Clang's -Wnonnull (as -Werror) flags this on the clang64 MinGW build. No call site relies on the default (JSString() is never invoked with zero arguments), so default to an empty string instead.