### PR TITLE
Darwin: fix VLA in Process::readString

### DIFF
--- a/Sources/Target/Darwin/Process.cpp
+++ b/Sources/Target/Darwin/Process.cpp
@@ -289,17 +289,18 @@ ErrorCode Process::readString(Address const &address, std::string &str,
   if (_currentThread == nullptr)
     return kErrorProcessNotFound;
 
-  char buf[length];
+  std::string buf(length, '\0');
   ErrorCode err;
 
-  err = mach().readMemory(_currentThread->tid(), address, buf, length, count);
+  err = mach().readMemory(_currentThread->tid(), address, buf.data(), length,
+                           count);
   if (err != kSuccess)
     return err;
 
-  if (strnlen(buf, length) == length)
+  if (strnlen(buf.data(), length) == length)
     return kErrorNameTooLong;
 
-  str = std::string(buf);
+  str = std::string(buf.data());
   return kSuccess;
 }
 


### PR DESCRIPTION
char buf[length] is a variable-length array, a non-standard Clang/GCC extension in C++. The macos-26-intel runner's newer Clang now flags this as an error via -Wvla-cxx-extension (part of -Wall/-Wextra), which the previous runner's toolchain didn't warn on.

Replace it with a dynamically-sized std::string used as the raw buffer, preserving the exact original behavior: read `length` bytes, reject as kErrorNameTooLong if no NUL terminator was found within them, otherwise construct the result from the NUL-terminated content.