### PR TITLE
GHA: remove seanmiddleditch/gha-setup-ninja

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: seanmiddleditch/gha-setup-ninja@v6
 
       - name: Configure
         run: |
@@ -318,7 +317,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: seanmiddleditch/gha-setup-ninja@v6
       - uses: actions/download-artifact@v8
         with:
           name: windows-regsgen2
@@ -364,21 +362,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -qq --no-install-recommends lzma-dev liblzma-dev
-
-      - if: ${{ !contains(matrix.runner, 'arm') }}
-        uses: seanmiddleditch/gha-setup-ninja@v6
-
-      - if: contains(matrix.runner, 'arm')
-        uses: seanmiddleditch/gha-setup-ninja@v6
-        with:
-          # TODO(andrurogerz): seanmiddleditch/gha-setup-ninja does not properly
-          # detect Linux on arm64 and always installs the x86_64 ninja package.
-          # For now, we can fix this by overriding the platform string to force
-          # the downloading the proper package. We also require a newer ninja
-          # version since aarch64 packages were not released until v1.12.0 and
-          # the default gha-setup-ninja installs is v1.11.1.
-          platform: linux-aarch64
-          version: 1.12.1 # latest sccache version
 
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23


### PR DESCRIPTION
The action's README states it is no longer necessary and no further development or maintenance will occur: Ninja now ships by default on all GitHub-hosted runner images used in this workflow. Verified against actions/runner-images' current manifests:

- windows-latest (Windows2022/2025): Ninja 1.13.2
- macos-26-intel (macos-26): Ninja 1.13.2
- ubuntu-latest (Ubuntu2404): Ninja 1.13.2
- ubuntu-24.04-arm (Ubuntu2404-Arm64): Ninja 1.13.2

Drop the four uses: seanmiddleditch/gha-setup-ninja@v6 steps (macos, android-windows-ndk, and both matrix legs of build-lldb-linux) along with the arm64-specific platform/version override workaround in build-lldb-linux, which existed only to compensate for the action's own broken arm64 detection and its default version predating aarch64 release artifacts -- moot now that the runner-provided ninja is used directly and is already new enough.