### PR TITLE
GHA: bring action pins up to date again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: compnerd/gha-setup-vsdevenv@main
+      - uses: compnerd/gha-setup-vsdevenv@v7
 
       - name: Install Build Tools
         run: choco install winflexbison3


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve dependency management by pinning the `compnerd/gha-setup-vsdevenv` action to a specific version.

Dependency management:

* Updated the `compnerd/gha-setup-vsdevenv` GitHub Action from the `main` branch to the stable `v7` release in `.github/workflows/build.yml` to ensure consistent and reproducible builds.