### PR TITLE
GHA: add Windows Store (UWP) build coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
     runs-on: windows-latest
 
     strategy:
+      fail-fast: false
       matrix:
         arch: ['Win32', 'x64']
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,44 @@ jobs:
           path: |
             ${{ github.workspace }}/BinaryCache/ds2/Release/ds2.exe
 
+  windows_store:
+    needs: [windows_tools]
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        arch: ['Win32', 'x64']
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Build Tools
+        run: choco install winflexbison3
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: windows-regsgen2
+          path: ${{ github.workspace }}/BinaryCache/RegsGen2/Release
+
+      - name: Configure
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/ds2 `
+                -C ${{ github.workspace }}/cmake/caches/MSVCWarnings.cmake `
+                -G "Visual Studio 18 2026" `
+                -A ${{ matrix.arch }} `
+                -D CMAKE_SYSTEM_NAME=WindowsStore `
+                -D CMAKE_SYSTEM_VERSION=10.0 `
+                -D DS2_REGSGEN2=${{ github.workspace }}/BinaryCache/RegsGen2/Release/regsgen2.exe `
+                -S ${{ github.workspace }}
+      - name: Build
+        run: cmake --build ${{ github.workspace }}/BinaryCache/ds2 --config Release
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: windows-store-${{ matrix.arch }}-ds2
+          path: |
+            ${{ github.workspace }}/BinaryCache/ds2/Release/ds2.exe
+
   bazel:
     runs-on: ubuntu-latest
     name: Bazel Build Check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,8 +422,24 @@ elseif(WIN32)
       foreach (FUNC ContinueDebugEvent DebugActiveProcess DebugActiveProcessStop
           GetModuleHandleA GetModuleHandleW GetWindowsDirectoryW ReadProcessMemory
           SetThreadContext TerminateThread VirtualAllocEx VirtualFreeEx
-          VirtualQueryEx WriteProcessMemory)
+          VirtualQueryEx WaitForDebugEvent WriteProcessMemory)
         CHECK_SYMBOL_EXISTS(${FUNC} windows.h HAVE_${FUNC})
+        if (HAVE_${FUNC})
+          target_compile_definitions(ds2 PRIVATE HAVE_${FUNC})
+        endif ()
+      endforeach()
+
+      # EnumProcessModules resolves to K32EnumProcessModules via psapi.h's own
+      # unconditional macro, so it needs its own header rather than the
+      # windows.h-based loop above.
+      CHECK_SYMBOL_EXISTS(EnumProcessModules psapi.h HAVE_EnumProcessModules)
+      if (HAVE_EnumProcessModules)
+        target_compile_definitions(ds2 PRIVATE HAVE_EnumProcessModules)
+      endif ()
+
+      # dbghelp.h's symbol handler APIs, used for backtrace symbolication.
+      foreach (FUNC SymInitialize SymFromAddr SymGetLineFromAddr64)
+        CHECK_SYMBOL_EXISTS(${FUNC} dbghelp.h HAVE_${FUNC})
         if (HAVE_${FUNC})
           target_compile_definitions(ds2 PRIVATE HAVE_${FUNC})
         endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "ARM" OR
 elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "X86" OR
       CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
   set(DS2_ARCHITECTURE X86)
-elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "X64" OR
+elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "X64|x64" OR
       CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|AMD64|x86_64")
   set(DS2_ARCHITECTURE X86_64)
 elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "RISCV32|RISCV64|RISCV128" OR
@@ -143,6 +143,11 @@ endforeach()
 
 if(ANDROID)
   set(RegsGenOS linux)
+elseif(WINDOWS_STORE)
+  # regsgen2 only knows the "windows" OS/ABI (it generates the same register
+  # layout regardless of Desktop vs UWP); CMAKE_SYSTEM_NAME is "WindowsStore"
+  # here, which regsgen2 would otherwise reject outright.
+  set(RegsGenOS windows)
 else()
   set(RegsGenOS $<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
 endif()

--- a/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
@@ -122,6 +122,13 @@ WINBASEAPI BOOL WINAPI WriteProcessMemory(
 );
 #endif
 
+#if !defined(HAVE_WaitForDebugEvent)
+WINBASEAPI BOOL APIENTRY WaitForDebugEvent(
+  _Out_ LPDEBUG_EVENT lpDebugEvent,
+  _In_  DWORD         dwMilliseconds
+);
+#endif
+
 #if !defined(HAVE_ContinueDebugEvent)
 WINBASEAPI BOOL WINAPI ContinueDebugEvent(
   _In_  DWORD dwProcessId,
@@ -170,6 +177,19 @@ WINBASEAPI SIZE_T WINAPI VirtualQueryEx(
 );
 #endif
 
+#if !defined(HAVE_EnumProcessModules)
+// psapi.h's #define EnumProcessModules -> K32EnumProcessModules (PSAPI_VERSION
+// > 1) is itself nested inside the same DESKTOP|SYSTEM|GAMES guard as the
+// rest of the header, so it's absent here too, and callers reference the
+// literal name "EnumProcessModules" directly, not the K32-prefixed one.
+BOOL WINAPI EnumProcessModules(
+  _In_                     HANDLE   hProcess,
+  _Out_writes_bytes_(cb)   HMODULE *lphModule,
+  _In_                     DWORD    cb,
+  _Out_                    LPDWORD  lpcbNeeded
+);
+#endif
+
 #if !defined(TH32CS_SNAPTHREAD)
 #define TH32CS_SNAPTHREAD 0x00000004
 #endif
@@ -182,6 +202,70 @@ typedef LONG (WINAPI *PTOP_LEVEL_EXCEPTION_FILTER)(
 
 #if !defined(HAVE_LPTOP_LEVEL_EXCEPTION_FILTER)
 typedef PTOP_LEVEL_EXCEPTION_FILTER LPTOP_LEVEL_EXCEPTION_FILTER;
+#endif
+
+// dbghelp.h's symbol handler: the whole header is unavailable outside the
+// Desktop/WER/Games partitions, so its types need re-declaring here too, not
+// just the functions that use them.
+#if !defined(HAVE_SymInitialize) || !defined(HAVE_SymFromAddr) ||            \
+    !defined(HAVE_SymGetLineFromAddr64)
+
+#if !defined(MAX_SYM_NAME)
+#define MAX_SYM_NAME 2000
+#endif
+
+typedef struct _SYMBOL_INFO {
+  ULONG   SizeOfStruct;
+  ULONG   TypeIndex;
+  ULONG64 Reserved[2];
+  ULONG   Index;
+  ULONG   Size;
+  ULONG64 ModBase;
+  ULONG   Flags;
+  ULONG64 Value;
+  ULONG64 Address;
+  ULONG   Register;
+  ULONG   Scope;
+  ULONG   Tag;
+  ULONG   NameLen;
+  ULONG   MaxNameLen;
+  CHAR    Name[1];
+} SYMBOL_INFO, *PSYMBOL_INFO;
+
+typedef struct _IMAGEHLP_LINE64 {
+  DWORD   SizeOfStruct;
+  PVOID   Key;
+  DWORD   LineNumber;
+  PCHAR   FileName;
+  DWORD64 Address;
+} IMAGEHLP_LINE64, *PIMAGEHLP_LINE64;
+
+#endif
+
+#if !defined(HAVE_SymInitialize)
+WINBASEAPI BOOL WINAPI SymInitialize(
+  _In_     HANDLE hProcess,
+  _In_opt_ PCSTR  UserSearchPath,
+  _In_     BOOL   fInvadeProcess
+);
+#endif
+
+#if !defined(HAVE_SymFromAddr)
+WINBASEAPI BOOL WINAPI SymFromAddr(
+  _In_      HANDLE       hProcess,
+  _In_      DWORD64      Address,
+  _Out_opt_ PDWORD64     Displacement,
+  _Inout_   PSYMBOL_INFO Symbol
+);
+#endif
+
+#if !defined(HAVE_SymGetLineFromAddr64)
+WINBASEAPI BOOL WINAPI SymGetLineFromAddr64(
+  _In_  HANDLE           hProcess,
+  _In_  DWORD64          qwAddr,
+  _Out_ PDWORD           pdwDisplacement,
+  _Out_ PIMAGEHLP_LINE64 Line64
+);
 #endif
 
 } // extern "C"

--- a/Sources/Utils/Backtrace.cpp
+++ b/Sources/Utils/Backtrace.cpp
@@ -16,6 +16,8 @@
 #include <dlfcn.h>
 #include <execinfo.h>
 #elif defined(OS_WIN32)
+#include "DebugServer2/Host/Windows/ExtraWrappers.h"
+
 #include <dbghelp.h>
 #include <windows.h>
 #include <mutex>


### PR DESCRIPTION
The WINDOWS_STORE-specific code paths -- ExtraWrappers.h's fallback declarations, the onecore link, the UWP-scoped feature checks just added -- have never been exercised by CI, which is exactly how the HAVE_${CHECK}/HAVE_${FUNC} bug sat unnoticed for as long as it did.

Add a windows_store job, mirroring the existing windows job (same actions/checkout, actions/download-artifact, and actions/upload-artifact pins, same regsgen2 host tool reused from windows_tools), that configures and builds ds2 for Win32 and x64 with
-D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0.