### PR TITLE
Windows: implement ARM64 hardware single-step

### DIFF
--- a/Headers/DebugServer2/Target/Windows/Process.h
+++ b/Headers/DebugServer2/Target/Windows/Process.h
@@ -75,6 +75,7 @@ public:
 
 public:
   ErrorCode wait() override;
+  ErrorCode afterResume() override;
 
 public:
   static Target::Process *Create(Host::ProcessSpawner &spawner);

--- a/Headers/DebugServer2/Target/Windows/Thread.h
+++ b/Headers/DebugServer2/Target/Windows/Thread.h
@@ -40,6 +40,9 @@ public:
                            Address const &address = Address()) override;
 
 public:
+  virtual ErrorCode afterResume();
+
+public:
   virtual ErrorCode readCPUState(Architecture::CPUState &state) override;
   virtual ErrorCode writeCPUState(Architecture::CPUState const &state) override;
 

--- a/Sources/Target/Windows/ARM/ThreadARM.cpp
+++ b/Sources/Target/Windows/ARM/ThreadARM.cpp
@@ -144,6 +144,13 @@ ErrorCode Thread::writeCPUState(Architecture::CPUState const &state) {
 
   return kSuccess;
 }
+
+ErrorCode Thread::afterResume() {
+  // Nothing to do here: 32-bit ARM single-steps in software (a temporary
+  // breakpoint via PrepareSoftwareSingleStep), which the breakpoint manager
+  // already cleans up on its own, unlike AArch64's PSTATE.SS/MDSCR_EL1.
+  return kSuccess;
+}
 } // namespace Windows
 } // namespace Target
 } // namespace ds2

--- a/Sources/Target/Windows/ARM64/ThreadARM64.cpp
+++ b/Sources/Target/Windows/ARM64/ThreadARM64.cpp
@@ -23,12 +23,27 @@ namespace ds2 {
 namespace Target {
 namespace Windows {
 
+namespace {
+// PSTATE.SS, per the ARMv8 architecture reference manual. Setting this bit
+// in Cpsr and resuming the thread arms a single hardware step: the kernel
+// arms and disarms the underlying MDSCR_EL1 trap transparently, the same way
+// it already does for EFLAGS.TF on x86, so no separate debug register access
+// is required from user mode.
+constexpr uint64_t kPSTATE_SS = 1ULL << 21;
+}
+
 ErrorCode Thread::step(int signal, Address const &address) {
-  // TODO(compnerd) AArch64 single-step requires setting the SS bit in
-  // MDSCR_EL1, which is not accessible from user mode via
-  // Get/SetThreadContext. Implement software single-step (as is done for
-  // 32-bit ARM) once an AArch64 instruction decoder is available.
-  return kErrorUnsupported;
+  CHK(modifyRegisters([](Architecture::CPUState &state) {
+    state.state64.gp.cpsr |= kPSTATE_SS;
+  }));
+
+  return resume(signal, address);
+}
+
+ErrorCode Thread::afterResume() {
+  return modifyRegisters([](Architecture::CPUState &state) {
+    state.state64.gp.cpsr &= ~kPSTATE_SS;
+  });
 }
 
 ErrorCode Thread::readCPUState(Architecture::CPUState &state) {

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -305,6 +305,22 @@ ErrorCode Process::wait() {
   }
 }
 
+ErrorCode Process::afterResume() {
+  // A normal exit reaches here too (wait() has already set _terminated and
+  // marked _currentThread kTerminated by this point), and the thread's
+  // handle is no longer valid to touch -- Thread::afterResume() would fail
+  // trying to Get/SetThreadContext on it. Skip it in that case, matching
+  // the isAlive() guard super::afterResume() applies to the rest of the
+  // resume bookkeeping.
+  if (isAlive()) {
+    // Give the current thread a chance to disarm anything it armed in
+    // Thread::step() (e.g. AArch64's PSTATE.SS) before falling through to
+    // the generic breakpoint handling.
+    CHK(_currentThread->afterResume());
+  }
+  return super::afterResume();
+}
+
 ErrorCode Process::readString(Address const &address, std::string &str,
                               size_t length, size_t *nread) {
   for (size_t i = 0; i < length; ++i) {

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -140,12 +140,26 @@ void Thread::updateState(DEBUG_EVENT const &de) {
       _stopInfo.clear();
       _process->resume();
       break;
-    case STATUS_BREAKPOINT:
-    case STATUS_SINGLE_STEP: {
+    case STATUS_BREAKPOINT: {
       _stopInfo.event = StopInfo::kEventStop;
       auto *hwBpm = process()->hardwareBreakpointManager();
       if (hwBpm == nullptr || !hwBpm->fillStopInfo(this, _stopInfo)) {
         _stopInfo.reason = StopInfo::kReasonBreakpoint;
+      }
+      break;
+    }
+    case STATUS_SINGLE_STEP: {
+      // Hardware breakpoints/watchpoints (DR0-3/DR7 on x86) also arrive as
+      // STATUS_SINGLE_STEP on Windows, not STATUS_BREAKPOINT, so this still
+      // has to consult the hardware breakpoint manager -- it's what fills
+      // in the watchpoint index/address and kReason*Watchpoint from DR6.
+      // Only fall back to kReasonTrace, not kReasonBreakpoint, once that
+      // comes back empty, so a completed step is still distinguishable
+      // from a breakpoint hit.
+      _stopInfo.event = StopInfo::kEventStop;
+      auto *hwBpm = process()->hardwareBreakpointManager();
+      if (hwBpm == nullptr || !hwBpm->fillStopInfo(this, _stopInfo)) {
+        _stopInfo.reason = StopInfo::kReasonTrace;
       }
       break;
     }

--- a/Sources/Target/Windows/X86/ThreadX86.cpp
+++ b/Sources/Target/Windows/X86/ThreadX86.cpp
@@ -122,6 +122,12 @@ ErrorCode Thread::writeCPUState(Architecture::CPUState const &state) {
 
   return kSuccess;
 }
+
+ErrorCode Thread::afterResume() {
+  // Nothing to do here: unlike AArch64's PSTATE.SS/MDSCR_EL1, x86 has no
+  // separate single-step arming state to disarm.
+  return kSuccess;
+}
 } // namespace Windows
 } // namespace Target
 } // namespace ds2

--- a/Sources/Target/Windows/X86_64/ThreadX86_64.cpp
+++ b/Sources/Target/Windows/X86_64/ThreadX86_64.cpp
@@ -109,6 +109,12 @@ ErrorCode Thread::writeCPUState(Architecture::CPUState const &state) {
 
   return kSuccess;
 }
+
+ErrorCode Thread::afterResume() {
+  // Nothing to do here: unlike AArch64's PSTATE.SS/MDSCR_EL1, x86 has no
+  // separate single-step arming state to disarm.
+  return kSuccess;
+}
 } // namespace Windows
 } // namespace Target
 } // namespace ds2


### PR DESCRIPTION
Thread::step() assumed AArch64 single-step needs MDSCR_EL1.SS, a system register Get/SetThreadContext can't reach from user mode, and returned kErrorUnsupported. That's not actually necessary: the real _ARM64_NT_CONTEXT has no Mdscr field, and LLDB's own Windows ARM64 support single-steps by setting PSTATE.SS (CPSR bit 21) through the ordinary SetThreadContext call and resuming -- the kernel arms and disarms the MDSCR_EL1 trap transparently, the same way it already does for EFLAGS.TF on x86.

step() now ORs PSTATE.SS into Cpsr (already read/written by this file's readCPUState/writeCPUState) via modifyRegisters() before resuming, matching Windows::X86_64 and Darwin::ARM64's equivalent step(). Clearing it back out belongs in afterResume(), once the step has actually trapped -- a hook Windows::Thread/Process didn't have at all, so this adds it: declared in Thread.h/Process.h, defined per-architecture like step() itself, with Process::afterResume() calling the current thread's afterResume() before deferring to ProcessBase::afterResume(). Without it PSTATE.SS would stay armed and every instruction after the first step would trap.

Verified with a full ARM64 cross-build (native regsgen2.exe supplying generated headers); linking initially failed on a duplicate Thread::afterResume() symbol until its definition moved out of the shared Thread.cpp into each per-architecture file, matching step().