### PR TITLE
Windows: implement platform mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,13 +432,26 @@ elseif(WIN32)
       # (WINAPI_PARTITION_DESKTOP is unavailable); ExtraWrappers.h provides
       # fallback declarations gated on the HAVE_* definitions computed here.
       # They are irrelevant (and skipped) for desktop Windows builds.
-      foreach (FUNC ContinueDebugEvent DebugActiveProcess DebugActiveProcessStop
-          GetModuleHandleA GetModuleHandleW GetWindowsDirectoryW ReadProcessMemory
-          SetThreadContext TerminateThread VirtualAllocEx VirtualFreeEx
-          VirtualQueryEx WaitForDebugEvent WriteProcessMemory)
+      foreach (FUNC ContinueDebugEvent CreateFileW DebugActiveProcess
+          DebugActiveProcessStop GetModuleHandleA GetModuleHandleW
+          GetWindowsDirectoryW ReadProcessMemory SetThreadContext
+          TerminateThread VirtualAllocEx VirtualFreeEx VirtualQueryEx
+          WaitForDebugEvent WriteProcessMemory)
         CHECK_SYMBOL_EXISTS(${FUNC} windows.h HAVE_${FUNC})
         if (HAVE_${FUNC})
           target_compile_definitions(ds2 PRIVATE HAVE_${FUNC})
+        endif ()
+      endforeach()
+
+      # HANDLE_FLAG_INHERIT, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, and
+      # STARTF_USESTDHANDLES are macros (not linkable symbols), but
+      # CHECK_SYMBOL_EXISTS works for those too -- it just verifies the
+      # preprocessor name resolves to something usable.
+      foreach (SYM HANDLE_FLAG_INHERIT PROC_THREAD_ATTRIBUTE_HANDLE_LIST
+          STARTF_USESTDHANDLES)
+        CHECK_SYMBOL_EXISTS(${SYM} windows.h HAVE_${SYM})
+        if (HAVE_${SYM})
+          target_compile_definitions(ds2 PRIVATE HAVE_${SYM})
         endif ()
       endforeach()
 
@@ -463,7 +476,8 @@ elseif(WIN32)
       include(CheckTypeSize)
       foreach (TYPE
           "struct _STARTUPINFOW" "struct _PROCESS_INFORMATION"
-          PTOP_LEVEL_EXCEPTION_FILTER LPTOP_LEVEL_EXCEPTION_FILTER)
+          PTOP_LEVEL_EXCEPTION_FILTER LPTOP_LEVEL_EXCEPTION_FILTER
+          STARTUPINFOEXW)
         string(REPLACE " " "_" SANITIZED_TYPE ${TYPE})
         CHECK_TYPE_SIZE(${TYPE} ${SANITIZED_TYPE})
         if (HAVE_${SANITIZED_TYPE})

--- a/Headers/DebugServer2/Host/File.h
+++ b/Headers/DebugServer2/Host/File.h
@@ -23,7 +23,7 @@ namespace Host {
 
 class File {
 public:
-  File(std::string const &path, OpenFlags flags, uint32_t mode);
+  File(const std::string &path, OpenFlags flags, uint32_t mode);
   ~File();
 
 public:
@@ -46,7 +46,7 @@ public:
 
 public:
   ErrorCode pread(ByteVector &buf, uint64_t &count, uint64_t offset);
-  ErrorCode pwrite(ByteVector const &buf, uint64_t &count, uint64_t offset);
+  ErrorCode pwrite(const ByteVector &buf, uint64_t &count, uint64_t offset);
   ErrorCode fstat(ByteVector &buffer) const;
 
 public:
@@ -54,20 +54,23 @@ public:
   ErrorCode lastError() const { return _lastError; }
 
 public:
-  static ErrorCode chmod(std::string const &path, uint32_t mode);
+  static ErrorCode chmod(const std::string &path, uint32_t mode);
 
 public:
-  static ErrorCode unlink(std::string const &path);
+  static ErrorCode unlink(const std::string &path);
 
 public:
-  static ErrorCode createDirectory(std::string const &path, uint32_t flags);
+  static ErrorCode createDirectory(const std::string &path, uint32_t flags);
 
 public:
-  static ErrorCode fileSize(std::string const &path, uint64_t &size);
-  static ErrorCode fileMode(std::string const &path, uint32_t &mode);
+  static ErrorCode fileSize(const std::string &path, uint64_t &size);
+  static ErrorCode fileMode(const std::string &path, uint32_t &mode);
 
 protected:
-  int _fd;
+  // Holds a POSIX file descriptor on POSIX, or a Windows HANDLE (cast
+  // through intptr_t, since a HANDLE does not safely fit in an int) on
+  // Windows.
+  intptr_t _fd;
   ErrorCode _lastError;
 };
 } // namespace Host

--- a/Headers/DebugServer2/Host/Socket.h
+++ b/Headers/DebugServer2/Host/Socket.h
@@ -51,6 +51,12 @@ public:
   inline bool valid() const { return (_handle != INVALID_SOCKET); }
 
 public:
+  // The underlying native socket handle. Used on Windows to hand a listening
+  // socket's handle to a relaunched child process (there is no fork() to
+  // rely on there); see Sources/main.cpp's Windows SlaveMain.
+  inline SOCKET native_handle() const { return _handle; }
+
+public:
   inline bool listening() const { return (_state == State::Listening); }
   inline bool connected() const override {
     return (_state == State::Connected);

--- a/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
@@ -88,6 +88,48 @@ typedef struct _PROCESS_INFORMATION {
 } PROCESS_INFORMATION, *LPPROCESS_INFORMATION;
 #endif
 
+#if !defined(HAVE_HANDLE_FLAG_INHERIT)
+#define HANDLE_FLAG_INHERIT 0x00000001
+#endif
+
+// InitializeProcThreadAttributeList/UpdateProcThreadAttribute and the
+// PROC_THREAD_ATTRIBUTE_LIST type are available in this partition already
+// (they back ConPTY support); only the STARTUPINFOEXW struct and the
+// PROC_THREAD_ATTRIBUTE_HANDLE_LIST attribute constant are missing.
+#if !defined(HAVE_PROC_THREAD_ATTRIBUTE_HANDLE_LIST)
+#if !defined(ProcThreadAttributeValue)
+#define ProcThreadAttributeValue(Number, Thread, Input, Additive)            \
+  ((Number) | ((Thread) ? 0x00010000 : 0) | ((Input) ? 0x00020000 : 0) |     \
+   ((Additive) ? 0x00040000 : 0))
+#endif
+// ProcThreadAttributeHandleList == 2 in the PROC_THREAD_ATTRIBUTE_NUM enum.
+#define PROC_THREAD_ATTRIBUTE_HANDLE_LIST                                   \
+  ProcThreadAttributeValue(2, FALSE, TRUE, FALSE)
+#endif
+
+#if !defined(HAVE_STARTUPINFOEXW)
+typedef struct _STARTUPINFOEXW {
+    STARTUPINFOW StartupInfo;
+    PPROC_THREAD_ATTRIBUTE_LIST lpAttributeList;
+} STARTUPINFOEXW, *LPSTARTUPINFOEXW;
+#endif
+
+#if !defined(HAVE_STARTF_USESTDHANDLES)
+#define STARTF_USESTDHANDLES 0x00000100
+#endif
+
+#if !defined(HAVE_CreateFileW)
+WINBASEAPI HANDLE WINAPI CreateFileW(
+  _In_     LPCWSTR               lpFileName,
+  _In_     DWORD                 dwDesiredAccess,
+  _In_     DWORD                 dwShareMode,
+  _In_opt_ LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+  _In_     DWORD                 dwCreationDisposition,
+  _In_     DWORD                 dwFlagsAndAttributes,
+  _In_opt_ HANDLE                hTemplateFile
+);
+#endif
+
 #if !defined(HAVE_TerminateThread)
 WINBASEAPI BOOL WINAPI TerminateThread(
   _Inout_ HANDLE hThread,

--- a/Headers/DebugServer2/Host/Windows/ProcessSpawner.h
+++ b/Headers/DebugServer2/Host/Windows/ProcessSpawner.h
@@ -12,17 +12,93 @@
 
 #include "DebugServer2/Types.h"
 
+#include <array>
 #include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
 
 namespace ds2 {
 namespace Host {
 
 class ProcessSpawner {
 protected:
+  enum class RedirectMode {
+    unset,
+    console,
+    null,
+    file,
+    buffer,
+  };
+
+protected:
+  // Named indices into _descriptors/_redirectThreads and the parallel local
+  // arrays run() builds up, one per standard stream.
+  enum class StreamIndex {
+    input,
+    output,
+    error,
+    count,
+  };
+
+  // StreamIndex doesn't implicitly convert to the array index types
+  // (size_t/DWORD) it is used with; this is the one place that conversion
+  // happens.
+  static constexpr size_t Index(StreamIndex stream) {
+    return static_cast<size_t>(stream);
+  }
+
+  // Deliberately not Index(StreamIndex::count): MSVC's C2131 rejects a
+  // static data member's in-class initializer calling a member function of
+  // the still-incomplete enclosing class, even a constexpr one.
+  static constexpr size_t kStreamCount =
+      static_cast<size_t>(StreamIndex::count);
+
+protected:
+  typedef std::function<void(void *buf, size_t size)> RedirectDelegate;
+
+protected:
+  struct RedirectDescriptor {
+    RedirectMode mode;
+    std::string path;
+    // The parent's end of a pipe, valid only for RedirectMode::buffer
+    // streams while the redirection thread is reading from it.
+    HANDLE handle;
+
+    RedirectDescriptor() : mode(RedirectMode::unset), handle(nullptr) {}
+  };
+
+protected:
   std::string _executablePath;
   StringCollection _arguments;
+  // Appended to the command line completely verbatim, after all quoted
+  // _arguments -- used only by setShellCommand(). cmd.exe re-parses its
+  // command text itself (via its own separate, and separately quirky, /C
+  // handling) rather than treating it as a normal, quoted argv element, so
+  // it needs to reach cmd.exe exactly as given rather than quoted the way a
+  // standard argv-consuming program would expect.
+  std::string _rawTrailingArgument;
   EnvironmentBlock _environment;
+  // Whether setEnvironment()/addEnvironment() was ever called, as opposed
+  // to _environment merely being empty. A caller can legitimately want an
+  // explicitly empty launch environment (ProcessLaunchMixin always calls
+  // setEnvironment(), even with nothing accumulated in it); that must still
+  // reach CreateProcessW as a valid, empty environment block, not collapse
+  // to "no environment was configured, inherit ours" the way run() treats
+  // callers (onLaunchDebugServer, onExecuteProgram) that never call either
+  // method at all.
+  bool _environmentSet;
   std::string _workingDirectory;
+  std::array<RedirectDescriptor, kStreamCount> _descriptors;
+  // One reader thread per RedirectMode::buffer stream (there can be up to two,
+  // output and error, draining concurrently -- a single multiplexed reader
+  // would risk a classic pipe deadlock: blocked reading a currently-empty
+  // stream while the child blocks writing to the other stream's full pipe).
+  std::array<std::thread, kStreamCount> _redirectThreads;
+  std::mutex _outputBufferMutex;
+  std::string _outputBuffer;
+  bool _debugOnCreate;
+  int _exitStatus;
   ProcessId _pid;
   HANDLE _handle;
   ThreadId _tid;
@@ -32,44 +108,56 @@ public:
   ProcessSpawner();
   ~ProcessSpawner();
 
-protected:
-  typedef std::function<void(void *buf, size_t size)> RedirectDelegate;
+public:
+  ProcessSpawner(const ProcessSpawner &) = delete;
+  ProcessSpawner &operator=(const ProcessSpawner &) = delete;
 
 public:
-  bool setExecutable(std::string const &path);
-  bool setShellCommand(std::string const &command);
-  bool setWorkingDirectory(std::string const &path);
+  bool setExecutable(const std::string &path);
+  bool setShellCommand(const std::string &command);
+  bool setWorkingDirectory(const std::string &path);
 
 public:
-  bool setArguments(StringCollection const &args);
+  bool setArguments(const StringCollection &args);
 
-  template <typename... Args> inline bool setArguments(Args const &... args) {
+  template <typename... Args> inline bool setArguments(const Args &...args) {
     std::string args_[] = {args...};
     return setArguments(StringCollection(&args_[0], &args_[sizeof...(Args)]));
   }
 
 public:
-  bool setEnvironment(EnvironmentBlock const &args);
-  bool addEnvironment(std::string const &key, std::string const &val);
+  bool setEnvironment(const EnvironmentBlock &args);
+  bool addEnvironment(const std::string &key, const std::string &val);
 
 public:
-  bool redirectInputToConsole() { return false; }
-  bool redirectOutputToConsole() { return false; }
-  bool redirectErrorToConsole() { return false; }
+  // Whether the created process should be started as a debuggee
+  // (DEBUG_PROCESS | DEBUG_ONLY_THIS_PROCESS). Defaults to false. Only
+  // Target::Windows::Process needs this set: it is the only caller that goes
+  // on to pump WaitForDebugEvent/ContinueDebugEvent for the child. Helper
+  // processes spawned to service platform-mode RPCs (launching a slave debug
+  // server, running a shell command, ...) must not be debugged, since
+  // nothing would ever continue them past their initial debug event and
+  // they would hang forever.
+  void setDebugOnCreate(bool debug) { _debugOnCreate = debug; }
 
 public:
-  bool redirectInputToNull() { return false; }
-  bool redirectOutputToNull() { return false; }
-  bool redirectErrorToNull() { return false; }
+  bool redirectInputToConsole();
+  bool redirectOutputToConsole();
+  bool redirectErrorToConsole();
 
 public:
-  bool redirectInputToFile(std::string const &path) { return false; }
-  bool redirectOutputToFile(std::string const &path) { return false; }
-  bool redirectErrorToFile(std::string const &path) { return false; }
+  bool redirectInputToNull();
+  bool redirectOutputToNull();
+  bool redirectErrorToNull();
 
 public:
-  bool redirectOutputToBuffer() { return false; }
-  bool redirectErrorToBuffer() { return false; }
+  bool redirectInputToFile(const std::string &path);
+  bool redirectOutputToFile(const std::string &path);
+  bool redirectErrorToFile(const std::string &path);
+
+public:
+  bool redirectOutputToBuffer();
+  bool redirectErrorToBuffer();
 
 public:
   bool redirectInputToTerminal() { return false; }
@@ -80,31 +168,28 @@ public:
 
 public:
   ErrorCode run(std::function<bool()> preExecAction = []() { return true; });
-  ErrorCode wait() { return kErrorUnsupported; }
-  bool isRunning() const { return false; }
-  void flushAndExit() {}
+  ErrorCode wait();
+  bool isRunning() const;
+  void flushAndExit();
 
 public:
   inline ProcessId pid() const { return _pid; }
   inline HANDLE handle() const { return _handle; }
   inline ThreadId tid() const { return _tid; }
   inline HANDLE threadHandle() const { return _threadHandle; }
-  inline int exitStatus() const { return 0; }
+  inline int exitStatus() const { return _exitStatus; }
   inline int signalCode() const { return 0; }
-  inline std::string const &executable() const { return _executablePath; }
-  inline StringCollection const &arguments() const { return _arguments; }
-  inline EnvironmentBlock const &environment() const { return _environment; }
+  inline const std::string &executable() const { return _executablePath; }
+  inline const StringCollection &arguments() const { return _arguments; }
+  inline const EnvironmentBlock &environment() const { return _environment; }
 
 public:
-  ErrorCode input(ByteVector const &buf) { return kErrorUnsupported; }
+  ErrorCode input(const ByteVector &buf) { return kErrorUnsupported; }
 
-  inline std::string const &output() const {
-    static std::string s;
-    return s;
-  }
+  inline const std::string &output() const { return _outputBuffer; }
 
 private:
-  void redirectionThread();
+  void redirectionThread(size_t index);
 };
 } // namespace Host
 } // namespace ds2

--- a/Headers/DebugServer2/Utils/Log.h
+++ b/Headers/DebugServer2/Utils/Log.h
@@ -36,6 +36,7 @@ void SetLogLevel(LogLevel level);
 void SetLogColorsEnabled(bool enabled);
 std::string const &GetLogOutputFilename();
 void SetLogOutputFilename(std::string const &filename);
+void SetLogOutputStream(FILE *stream);
 
 void Log(int level, char const *classname, char const *funcname,
          char const *format, ...) DS2_ATTRIBUTE_PRINTF(4, 5);

--- a/Sources/Host/Windows/File.cpp
+++ b/Sources/Host/Windows/File.cpp
@@ -11,44 +11,333 @@
 #include "DebugServer2/Host/File.h"
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Host/Windows/ExtraWrappers.h"
+#include "DebugServer2/Utils/String.h"
+
+#include <algorithm>
+#include <memory>
+#include <windows.h>
 
 namespace ds2 {
 namespace Host {
 
-File::File(std::string const &path, OpenFlags flags, uint32_t mode)
-    : _fd(-1), _lastError(kErrorUnsupported) {}
+namespace {
 
-File::~File() = default;
+DWORD ConvertAccessFlags(OpenFlags flags) {
+  DWORD access = 0;
+  if (flags & kOpenFlagRead)
+    access |= GENERIC_READ;
+  if (flags & kOpenFlagWrite)
+    access |= GENERIC_WRITE;
+  if (flags & kOpenFlagAppend)
+    access |= FILE_APPEND_DATA;
+  return access;
+}
+
+DWORD ConvertCreationDisposition(OpenFlags flags) {
+  if (flags & kOpenFlagCreate) {
+    if (flags & kOpenFlagNewOnly)
+      return CREATE_NEW;
+    return (flags & kOpenFlagTruncate) ? CREATE_ALWAYS : OPEN_ALWAYS;
+  }
+  return (flags & kOpenFlagTruncate) ? TRUNCATE_EXISTING : OPEN_EXISTING;
+}
+
+// Windows only models a read-only bit, not the full POSIX permission space;
+// synthesize a plausible mode from what actually exists on the file.
+uint32_t SynthesizeMode(DWORD attributes) {
+  bool isDirectory = (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+  bool readOnly = (attributes & FILE_ATTRIBUTE_READONLY) != 0;
+
+  uint32_t mode = isDirectory ? 0040000u : 0100000u; // S_IFDIR / S_IFREG
+  if (isDirectory)
+    mode |= readOnly ? 0555u : 0755u;
+  else
+    mode |= readOnly ? 0444u : 0644u;
+  return mode;
+}
+
+// Windows is always little-endian; reversing the bytes of a little-endian
+// value yields its big-endian representation.
+template <typename T> T HostToBigEndian(T value) {
+  T result;
+  const auto *src = reinterpret_cast<const uint8_t *>(&value);
+  auto *dst = reinterpret_cast<uint8_t *>(&result);
+  for (size_t i = 0; i < sizeof(T); ++i)
+    dst[i] = src[sizeof(T) - 1 - i];
+  return result;
+}
+
+uint64_t FileTimeToUnixTime(const FILETIME &fileTime) {
+  ULARGE_INTEGER uli;
+  uli.LowPart = fileTime.dwLowDateTime;
+  uli.HighPart = fileTime.dwHighDateTime;
+
+  // FILETIME counts 100ns intervals since 1601-01-01; this is the number of
+  // such intervals between 1601-01-01 and the Unix epoch (1970-01-01).
+  static const uint64_t kEpochDifference = 116444736000000000ULL;
+  if (uli.QuadPart < kEpochDifference)
+    return 0;
+
+  return (uli.QuadPart - kEpochDifference) / 10000000ULL;
+}
+
+// Returns the length of the root component of a normalized (backslash-
+// separated) Windows path -- a drive letter ("C:\") or a UNC server/share
+// ("\\server\share\") -- or 0 if the path has no recognizable root (e.g. a
+// relative path). Hand-rolled rather than using PathCchSkipRoot: pathcch.h's
+// functions require Windows 8+, but this project's Windows baseline
+// (WINVER/_WIN32_WINNT in CMakeLists.txt) is Vista.
+size_t SkipRoot(const std::wstring &path) {
+  if (path.size() >= 2 && path[1] == L':') {
+    size_t end = 2;
+    if (end < path.size() && path[end] == L'\\')
+      ++end;
+    return end;
+  }
+
+  if (path.size() >= 2 && path[0] == L'\\' && path[1] == L'\\') {
+    size_t pos = 2;
+    for (int component = 0; component < 2 && pos < path.size(); ++component) {
+      size_t separator = path.find(L'\\', pos);
+      if (separator == std::wstring::npos) {
+        pos = path.size();
+        break;
+      }
+      pos = separator + 1;
+    }
+    return pos;
+  }
+
+  return 0;
+}
+
+} // namespace
+
+File::File(const std::string &path, OpenFlags flags, uint32_t mode)
+    : _fd(reinterpret_cast<intptr_t>(INVALID_HANDLE_VALUE)),
+      _lastError(kErrorInvalidHandle) {
+  DWORD access = ConvertAccessFlags(flags);
+  DWORD disposition = ConvertCreationDisposition(flags);
+  DWORD attributes = ((flags & kOpenFlagCreate) && (mode & 0222) == 0)
+                         ? FILE_ATTRIBUTE_READONLY
+                         : FILE_ATTRIBUTE_NORMAL;
+  // Mirror O_NOFOLLOW: open the reparse point itself instead of
+  // transparently traversing a symlink/junction to its target.
+  if (flags & kOpenFlagNoFollow)
+    attributes |= FILE_FLAG_OPEN_REPARSE_POINT;
+
+  HANDLE handle =
+      ::CreateFileW(ds2::Utils::NarrowToWideString(path).c_str(), access,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    nullptr, disposition, attributes, nullptr);
+
+  if (handle == INVALID_HANDLE_VALUE) {
+    _lastError = Platform::TranslateError();
+    return;
+  }
+
+  if (flags & kOpenFlagNoFollow) {
+    BY_HANDLE_FILE_INFORMATION info;
+    if (::GetFileInformationByHandle(handle, &info) &&
+        (info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
+      // The path names a symlink/junction; fail instead of handing back a
+      // reparse-point handle to it, just as the POSIX O_NOFOLLOW path fails
+      // to open a symlink rather than silently following it.
+      ::CloseHandle(handle);
+      _lastError = kErrorInvalidArgument;
+      return;
+    }
+  }
+
+  _fd = reinterpret_cast<intptr_t>(handle);
+  _lastError = kSuccess;
+}
+
+File::~File() {
+  if (valid())
+    ::CloseHandle(reinterpret_cast<HANDLE>(_fd));
+}
 
 ErrorCode File::pread(ByteVector &buf, uint64_t &count, uint64_t offset) {
-  return kErrorUnsupported;
+  if (!valid())
+    return _lastError = kErrorInvalidHandle;
+
+  auto countArg = static_cast<DWORD>(count);
+  buf.resize(countArg);
+
+  OVERLAPPED overlapped = {};
+  overlapped.Offset = static_cast<DWORD>(offset & 0xffffffffull);
+  overlapped.OffsetHigh = static_cast<DWORD>(offset >> 32);
+
+  DWORD nRead = 0;
+  if (!::ReadFile(reinterpret_cast<HANDLE>(_fd), buf.data(), countArg, &nRead,
+                  &overlapped)) {
+    // A positioned read (via the OVERLAPPED offset fields) at or past the
+    // end of the file fails with ERROR_HANDLE_EOF on a synchronous handle,
+    // unlike an unpositioned read, which just returns 0 bytes. Treat it as
+    // a normal, successful end-of-file read rather than an error.
+    DWORD error = ::GetLastError();
+    if (error != ERROR_HANDLE_EOF)
+      return _lastError = Platform::TranslateError(error);
+    nRead = 0;
+  }
+
+  buf.resize(nRead);
+  count = static_cast<uint64_t>(nRead);
+
+  return _lastError = kSuccess;
 }
 
-ErrorCode File::pwrite(ByteVector const &buf, uint64_t &count,
+ErrorCode File::pwrite(const ByteVector &buf, uint64_t &count,
                        uint64_t offset) {
-  return kErrorUnsupported;
+  DS2ASSERT(count > 0);
+
+  if (!valid())
+    return _lastError = kErrorInvalidHandle;
+
+  auto countArg = static_cast<DWORD>(count);
+
+  OVERLAPPED overlapped = {};
+  overlapped.Offset = static_cast<DWORD>(offset & 0xffffffffull);
+  overlapped.OffsetHigh = static_cast<DWORD>(offset >> 32);
+
+  DWORD nWritten = 0;
+  if (!::WriteFile(reinterpret_cast<HANDLE>(_fd), buf.data(), countArg,
+                   &nWritten, &overlapped))
+    return _lastError = Platform::TranslateError();
+
+  count = static_cast<uint64_t>(nWritten);
+
+  return _lastError = kSuccess;
 }
 
+// lldb expects stat data is returned as a packed buffer with total size of 64
+// bytes. The field order is the same as the POSIX defined stat struct. All
+// fields are encoded as 4-byte, big-endian unsigned integers except for
+// st_size, st_blksize, and st_blocks which are all 8-byte, big-endian unsigned
+// integers.
 ErrorCode File::fstat(ByteVector &buffer) const {
-  return kErrorUnsupported;
+  if (!valid())
+    return kErrorInvalidHandle;
+
+  BY_HANDLE_FILE_INFORMATION info;
+  if (!::GetFileInformationByHandle(reinterpret_cast<HANDLE>(_fd), &info))
+    return Platform::TranslateError();
+
+  uint64_t size =
+      (static_cast<uint64_t>(info.nFileSizeHigh) << 32) | info.nFileSizeLow;
+  uint32_t mode = SynthesizeMode(info.dwFileAttributes);
+  uint64_t blockSize = static_cast<uint64_t>(Platform::GetPageSize());
+  uint64_t blocks = blockSize == 0 ? 0 : (size + blockSize - 1) / blockSize;
+
+  const auto appendInteger = [&buffer](auto value) -> void {
+    auto be = HostToBigEndian(value);
+    buffer.insert(buffer.end(), reinterpret_cast<uint8_t *>(&be),
+                  reinterpret_cast<uint8_t *>(&be) + sizeof(be));
+  };
+
+  appendInteger(uint32_t(0));                                // st_dev
+  appendInteger(uint32_t(0));                                // st_ino
+  appendInteger(mode);                                       // st_mode
+  appendInteger(static_cast<uint32_t>(info.nNumberOfLinks)); // st_nlink
+  appendInteger(uint32_t(0));                                // st_uid
+  appendInteger(uint32_t(0));                                // st_gid
+  appendInteger(uint32_t(0));                                // st_rdev
+  appendInteger(size);                                       // st_size
+  appendInteger(blockSize);                                  // st_blksize
+  appendInteger(blocks);                                     // st_blocks
+  appendInteger(static_cast<uint32_t>(
+      FileTimeToUnixTime(info.ftLastAccessTime))); // st_atime
+  appendInteger(static_cast<uint32_t>(
+      FileTimeToUnixTime(info.ftLastWriteTime))); // st_mtime
+  appendInteger(static_cast<uint32_t>(
+      FileTimeToUnixTime(info.ftCreationTime))); // st_ctime
+  DS2ASSERT(buffer.size() == 64);
+
+  return kSuccess;
 }
 
-ErrorCode File::chmod(std::string const &path, uint32_t mode) {
-  return kErrorUnsupported;
+ErrorCode File::chmod(const std::string &path, uint32_t mode) {
+  std::wstring widePath = ds2::Utils::NarrowToWideString(path);
+
+  DWORD attributes = ::GetFileAttributesW(widePath.c_str());
+  if (attributes == INVALID_FILE_ATTRIBUTES)
+    return Platform::TranslateError();
+
+  // Windows only models a read-only bit; map the owner-write permission bit
+  // onto it since that is the closest POSIX equivalent.
+  if (mode & 0200)
+    attributes &= ~FILE_ATTRIBUTE_READONLY;
+  else
+    attributes |= FILE_ATTRIBUTE_READONLY;
+
+  if (!::SetFileAttributesW(widePath.c_str(), attributes))
+    return Platform::TranslateError();
+
+  return kSuccess;
 }
 
-ErrorCode File::unlink(std::string const &path) { return kErrorUnsupported; }
+ErrorCode File::unlink(const std::string &path) {
+  if (!::DeleteFileW(ds2::Utils::NarrowToWideString(path).c_str()))
+    return Platform::TranslateError();
 
-ErrorCode File::createDirectory(std::string const &path, uint32_t flags) {
-  return kErrorUnsupported;
+  return kSuccess;
 }
 
-ErrorCode File::fileSize(std::string const &path, uint64_t &size) {
-  return kErrorUnsupported;
+ErrorCode File::createDirectory(const std::string &path, uint32_t flags) {
+  // Normalize '/' to '\' first: paths arrive from the wire and may use
+  // either separator, but the component-splitting loop below only
+  // recognizes '\' as a boundary.
+  std::wstring canonicalStr = ds2::Utils::NarrowToWideString(path);
+  std::replace(canonicalStr.begin(), canonicalStr.end(), L'/', L'\\');
+
+  // Skip the root -- a drive letter ("C:\") or a UNC server/share
+  // ("\\server\share\") -- neither of which can themselves be created as a
+  // directory. SkipRoot returns 0 for a path with no recognizable root (a
+  // relative path); walk the whole string in that case instead of treating
+  // it as an error, matching how a relative path was always handled here.
+  size_t searchFrom = SkipRoot(canonicalStr);
+
+  // Each parent directory must be created individually, if it does not
+  // exist.
+  for (;;) {
+    size_t boundary = canonicalStr.find(L'\\', searchFrom);
+    std::wstring partialPath = canonicalStr.substr(0, boundary);
+    if (!partialPath.empty() &&
+        !::CreateDirectoryW(partialPath.c_str(), nullptr)) {
+      ErrorCode error = Platform::TranslateError();
+      if (error != kErrorAlreadyExist)
+        return error;
+    }
+
+    if (boundary == std::wstring::npos)
+      return kSuccess;
+    searchFrom = boundary + 1;
+  }
 }
 
-ErrorCode File::fileMode(std::string const &path, uint32_t &mode) {
-  return kErrorUnsupported;
+ErrorCode File::fileSize(const std::string &path, uint64_t &size) {
+  WIN32_FILE_ATTRIBUTE_DATA attributes;
+  if (!::GetFileAttributesExW(ds2::Utils::NarrowToWideString(path).c_str(),
+                              GetFileExInfoStandard, &attributes))
+    return Platform::TranslateError();
+
+  size = (static_cast<uint64_t>(attributes.nFileSizeHigh) << 32) |
+         attributes.nFileSizeLow;
+  return kSuccess;
+}
+
+ErrorCode File::fileMode(const std::string &path, uint32_t &mode) {
+  WIN32_FILE_ATTRIBUTE_DATA attributes;
+  if (!::GetFileAttributesExW(ds2::Utils::NarrowToWideString(path).c_str(),
+                              GetFileExInfoStandard, &attributes))
+    return Platform::TranslateError();
+
+  // Match the POSIX implementation (ALLPERMS & st_mode): vFile:mode reports
+  // permission bits only. SynthesizeMode() also encodes the S_IFDIR/S_IFREG
+  // file-type bits fstat's st_mode needs, so mask those back out here.
+  mode = SynthesizeMode(attributes.dwFileAttributes) & 0777;
+  return kSuccess;
 }
 
 } // namespace Host

--- a/Sources/Host/Windows/Platform.cpp
+++ b/Sources/Host/Windows/Platform.cpp
@@ -246,12 +246,33 @@ ErrorCode Platform::TranslateError(DWORD error) {
   case ERROR_NOT_SUPPORTED:
     return ds2::kErrorUnsupported;
   case ERROR_FILE_EXISTS:
+  case ERROR_ALREADY_EXISTS:
     return ds2::kErrorAlreadyExist;
   case ERROR_INVALID_PARAMETER:
     return ds2::kErrorInvalidArgument;
   case ERROR_BAD_EXE_FORMAT:
     return ds2::kErrorInvalidArgument;
   case ERROR_PARTIAL_COPY:
+    return ds2::kErrorNoSpace;
+  // Reachable from CreateFileW on a remote client's vFile:open path, whose
+  // path argument is untrusted input -- map these instead of falling into
+  // the default/DS2BUG case below, which would abort the whole ds2 server
+  // over a bad or busy path rather than returning an F-packet error.
+  case ERROR_SHARING_VIOLATION:
+  case ERROR_LOCK_VIOLATION:
+    return ds2::kErrorBusy;
+  case ERROR_INVALID_NAME:
+  case ERROR_BAD_PATHNAME:
+  case ERROR_DIRECTORY:
+    return ds2::kErrorInvalidArgument;
+  case ERROR_FILENAME_EXCED_RANGE:
+    return ds2::kErrorNameTooLong;
+  // Reachable from WriteFile on a remote client's vFile:pwrite path when the
+  // volume backing the target file fills up -- map these too, for the same
+  // reason as the CreateFileW cases above (a full disk shouldn't abort the
+  // whole ds2 server).
+  case ERROR_DISK_FULL:
+  case ERROR_HANDLE_DISK_FULL:
     return ds2::kErrorNoSpace;
   default:
     DS2BUG("unknown error code: %#lx", error);
@@ -376,8 +397,25 @@ void Platform::EnumerateProcesses(
 }
 
 bool Platform::TerminateProcess(ProcessId pid) {
-  // TODO(andrurogerz): implement using OpenProcess and TerminateProcess.
-  return false;
+  HANDLE processHandle =
+      ::OpenProcess(PROCESS_TERMINATE | SYNCHRONIZE, FALSE, pid);
+  if (processHandle == nullptr)
+    return false;
+
+  bool terminated = ::TerminateProcess(processHandle, 1) == TRUE;
+  if (terminated) {
+    // TerminateProcess only queues the request; it does not wait for the
+    // process to actually exit. Without waiting here, a caller that treats
+    // a true return as "the pid is gone" (e.g. dropping it from a tracked-
+    // process list right away) can race a process that is still tearing
+    // down and still holding files/ports open.
+    terminated =
+        ::WaitForSingleObject(processHandle, INFINITE) == WAIT_OBJECT_0;
+  }
+
+  ::CloseHandle(processHandle);
+
+  return terminated;
 }
 
 std::string Platform::GetThreadName(ProcessId pid, ThreadId tid) {

--- a/Sources/Host/Windows/ProcessSpawner.cpp
+++ b/Sources/Host/Windows/ProcessSpawner.cpp
@@ -14,6 +14,9 @@
 #include "DebugServer2/Utils/Log.h"
 #include "DebugServer2/Utils/String.h"
 
+#include <algorithm>
+#include <mutex>
+#include <vector>
 #include <windows.h>
 
 using ds2::Host::Platform;
@@ -21,11 +24,33 @@ using ds2::Host::Platform;
 namespace ds2 {
 namespace Host {
 
-ProcessSpawner::ProcessSpawner() : _pid(0), _handle(0) {}
+ProcessSpawner::ProcessSpawner()
+    : _environmentSet(false), _debugOnCreate(false), _exitStatus(0), _pid(0),
+      _handle(nullptr), _tid(0), _threadHandle(nullptr) {}
 
-ProcessSpawner::~ProcessSpawner() {}
+ProcessSpawner::~ProcessSpawner() { flushAndExit(); }
 
-bool ProcessSpawner::setExecutable(std::string const &path) {
+void ProcessSpawner::flushAndExit() {
+  for (auto &thread : _redirectThreads)
+    if (thread.joinable())
+      thread.join();
+
+  // wait() already closes and nulls these out; if it was never called (the
+  // common case for platform-mode helper launches that only ever need the
+  // pid, e.g. ProcessLaunchMixin::spawnProcess()), these handles would
+  // otherwise stay open for the entire remaining lifetime of this ds2
+  // process -- one leaked pair per launch, on a long-lived platform server.
+  if (_threadHandle != nullptr) {
+    ::CloseHandle(_threadHandle);
+    _threadHandle = nullptr;
+  }
+  if (_handle != nullptr) {
+    ::CloseHandle(_handle);
+    _handle = nullptr;
+  }
+}
+
+bool ProcessSpawner::setExecutable(const std::string &path) {
   if (_pid != 0)
     return false;
 
@@ -33,16 +58,33 @@ bool ProcessSpawner::setExecutable(std::string const &path) {
   return true;
 }
 
-bool ProcessSpawner::setShellCommand(std::string const &command) {
-  if (_pid != 0) {
+bool ProcessSpawner::setShellCommand(const std::string &command) {
+  if (_pid != 0)
     return false;
+
+  // Unlike POSIX's execve(), CreateProcessW never interprets its command
+  // line -- setExecutable(command) would make the whole shell command (e.g.
+  // "echo hi" or "dir /w") a single, literal executable name to look up,
+  // which fails for anything but a bare, argument-less program. Route
+  // through the configured shell instead, exactly as one would type
+  // `%COMSPEC% /C <command>` -- the same thing setShellCommand's POSIX
+  // counterpart does with `sh -c`.
+  std::wstring comspec;
+  DWORD size = ::GetEnvironmentVariableW(L"COMSPEC", nullptr, 0);
+  if (size > 0) {
+    comspec.resize(size);
+    comspec.resize(::GetEnvironmentVariableW(L"COMSPEC", &comspec[0], size));
   }
 
-  setExecutable(command);
+  setExecutable(comspec.empty() ? "cmd.exe"
+                                : ds2::Utils::WideToNarrowString(comspec));
+  setArguments(StringCollection{"/C"});
+  // Not a normal, quoted _arguments element -- see _rawTrailingArgument.
+  _rawTrailingArgument = command;
   return true;
 }
 
-bool ProcessSpawner::setArguments(StringCollection const &args) {
+bool ProcessSpawner::setArguments(const StringCollection &args) {
   if (_pid != 0)
     return false;
 
@@ -50,24 +92,26 @@ bool ProcessSpawner::setArguments(StringCollection const &args) {
   return true;
 }
 
-bool ProcessSpawner::setEnvironment(EnvironmentBlock const &env) {
+bool ProcessSpawner::setEnvironment(const EnvironmentBlock &env) {
   if (_pid != 0)
     return false;
 
   _environment = env;
+  _environmentSet = true;
   return true;
 }
 
-bool ProcessSpawner::addEnvironment(std::string const &key,
-                                    std::string const &val) {
+bool ProcessSpawner::addEnvironment(const std::string &key,
+                                    const std::string &val) {
   if (_pid != 0)
     return false;
 
   _environment[key] = val;
+  _environmentSet = true;
   return true;
 }
 
-bool ProcessSpawner::setWorkingDirectory(std::string const &path) {
+bool ProcessSpawner::setWorkingDirectory(const std::string &path) {
   if (_pid != 0)
     return false;
 
@@ -75,65 +119,563 @@ bool ProcessSpawner::setWorkingDirectory(std::string const &path) {
   return true;
 }
 
-ErrorCode ProcessSpawner::run(std::function<bool()> preExecAction) {
-  std::vector<WCHAR> commandLine;
-  std::vector<WCHAR> environment;
-  STARTUPINFOW si;
-  PROCESS_INFORMATION pi;
+//
+// Redirection setup -- these only record intent; run() does the actual work.
+//
+bool ProcessSpawner::redirectInputToConsole() {
+  if (_pid != 0 ||
+      _descriptors[Index(StreamIndex::input)].mode != RedirectMode::unset)
+    return false;
 
-  commandLine.push_back(L'"');
-  std::wstring wideExecutablePath =
-      ds2::Utils::NarrowToWideString(_executablePath);
-  commandLine.insert(commandLine.end(), wideExecutablePath.begin(),
-                     wideExecutablePath.end());
-  commandLine.push_back(L'"');
-  for (auto const &arg : _arguments) {
-    commandLine.push_back(L' ');
-    commandLine.push_back(L'"');
+  _descriptors[Index(StreamIndex::input)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::input)].mode = RedirectMode::console;
+  return true;
+}
+
+bool ProcessSpawner::redirectOutputToConsole() {
+  if (_pid != 0 ||
+      _descriptors[Index(StreamIndex::output)].mode != RedirectMode::unset)
+    return false;
+
+  _descriptors[Index(StreamIndex::output)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::output)].mode = RedirectMode::console;
+  return true;
+}
+
+bool ProcessSpawner::redirectErrorToConsole() {
+  if (_pid != 0 ||
+      _descriptors[Index(StreamIndex::error)].mode != RedirectMode::unset)
+    return false;
+
+  _descriptors[Index(StreamIndex::error)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::error)].mode = RedirectMode::console;
+  return true;
+}
+
+bool ProcessSpawner::redirectInputToNull() {
+  if (_pid != 0 ||
+      _descriptors[Index(StreamIndex::input)].mode != RedirectMode::unset)
+    return false;
+
+  _descriptors[Index(StreamIndex::input)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::input)].mode = RedirectMode::null;
+  return true;
+}
+
+bool ProcessSpawner::redirectOutputToNull() {
+  if (_pid != 0 ||
+      _descriptors[Index(StreamIndex::output)].mode != RedirectMode::unset)
+    return false;
+
+  _descriptors[Index(StreamIndex::output)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::output)].mode = RedirectMode::null;
+  return true;
+}
+
+bool ProcessSpawner::redirectErrorToNull() {
+  if (_pid != 0 ||
+      _descriptors[Index(StreamIndex::error)].mode != RedirectMode::unset)
+    return false;
+
+  _descriptors[Index(StreamIndex::error)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::error)].mode = RedirectMode::null;
+  return true;
+}
+
+bool ProcessSpawner::redirectInputToFile(const std::string &path) {
+  if (_pid != 0 || path.empty() ||
+      _descriptors[Index(StreamIndex::input)].mode != RedirectMode::unset)
+    return false;
+
+  _descriptors[Index(StreamIndex::input)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::input)].mode = RedirectMode::file;
+  _descriptors[Index(StreamIndex::input)].path = path;
+  return true;
+}
+
+bool ProcessSpawner::redirectOutputToFile(const std::string &path) {
+  if (_pid != 0 || path.empty() ||
+      _descriptors[Index(StreamIndex::output)].mode != RedirectMode::unset)
+    return false;
+
+  _descriptors[Index(StreamIndex::output)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::output)].mode = RedirectMode::file;
+  _descriptors[Index(StreamIndex::output)].path = path;
+  return true;
+}
+
+bool ProcessSpawner::redirectErrorToFile(const std::string &path) {
+  if (_pid != 0 || path.empty() ||
+      _descriptors[Index(StreamIndex::error)].mode != RedirectMode::unset)
+    return false;
+
+  _descriptors[Index(StreamIndex::error)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::error)].mode = RedirectMode::file;
+  _descriptors[Index(StreamIndex::error)].path = path;
+  return true;
+}
+
+bool ProcessSpawner::redirectOutputToBuffer() {
+  if (_pid != 0 ||
+      _descriptors[Index(StreamIndex::output)].mode != RedirectMode::unset)
+    return false;
+
+  _descriptors[Index(StreamIndex::output)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::output)].mode = RedirectMode::buffer;
+  return true;
+}
+
+bool ProcessSpawner::redirectErrorToBuffer() {
+  if (_pid != 0 ||
+      _descriptors[Index(StreamIndex::error)].mode != RedirectMode::unset)
+    return false;
+
+  _descriptors[Index(StreamIndex::error)] = RedirectDescriptor();
+  _descriptors[Index(StreamIndex::error)].mode = RedirectMode::buffer;
+  return true;
+}
+
+namespace {
+
+bool NeedsQuoting(const std::wstring &arg) {
+  return arg.empty() || arg.find_first_of(L" \t\"") != std::wstring::npos;
+}
+
+std::wstring BuildCommandLine(const std::string &executablePath,
+                              const StringCollection &arguments,
+                              const std::string &rawTrailingArgument) {
+  std::wstring commandLine;
+  commandLine += L'"';
+  commandLine += ds2::Utils::NarrowToWideString(executablePath);
+  commandLine += L'"';
+  for (const auto &arg : arguments) {
+    commandLine += L' ';
     std::wstring wideArg = ds2::Utils::NarrowToWideString(arg);
-    for (auto const &ch : wideArg) {
-      if (ch == L'"')
-        commandLine.push_back(L'\\');
-      commandLine.push_back(ch);
+    if (!NeedsQuoting(wideArg)) {
+      // Leave arguments that plainly don't need it (e.g. cmd.exe's "/C")
+      // unquoted -- harmless for a standard argv-consuming program (an
+      // unquoted single word parses identically to a quoted one), and it
+      // keeps cmd.exe's own switch scan (which works off the raw command
+      // line text, not a parsed argv) recognizing "/C" as the switch it is.
+      commandLine += wideArg;
+      continue;
     }
-    commandLine.push_back(L'"');
-  }
-  commandLine.push_back(L'\0');
 
-  for (auto const &env : _environment) {
-    std::wstring wideKey = ds2::Utils::NarrowToWideString(env.first);
-    std::wstring wideValue = ds2::Utils::NarrowToWideString(env.second);
+    commandLine += L'"';
+    for (const auto &ch : wideArg) {
+      if (ch == L'"')
+        commandLine += L'\\';
+      commandLine += ch;
+    }
+    commandLine += L'"';
+  }
+
+  if (!rawTrailingArgument.empty()) {
+    // setShellCommand()'s command text, appended completely verbatim rather
+    // than quoted like a normal argv element. cmd.exe re-parses whatever
+    // follows "/C" itself, via its own separate (and separately quirky)
+    // rules for when to strip a surrounding quote pair back off; quoting
+    // this the same way a standard argv-consuming program would want is
+    // unnecessary (cmd.exe isn't one) and, for anything that is itself a
+    // nested "cmd /c ..." invocation, actively wrong -- verified empirically
+    // against real cmd.exe rather than derived from its under-documented
+    // stripping algorithm.
+    commandLine += L' ';
+    commandLine += ds2::Utils::NarrowToWideString(rawTrailingArgument);
+  }
+
+  return commandLine;
+}
+
+std::vector<WCHAR> BuildEnvironmentBlock(const EnvironmentBlock &env) {
+  std::vector<WCHAR> environment;
+  for (const auto &e : env) {
+    std::wstring wideKey = ds2::Utils::NarrowToWideString(e.first);
+    std::wstring wideValue = ds2::Utils::NarrowToWideString(e.second);
     environment.insert(environment.end(), wideKey.begin(), wideKey.end());
     environment.push_back(L'=');
     environment.insert(environment.end(), wideValue.begin(), wideValue.end());
     environment.push_back(L'\0');
   }
+  // A Windows environment block must end with an extra null marking the end
+  // of the list. For a non-empty block the loop above already left one
+  // trailing null, so the push below completes the required double-null
+  // terminator. For an EMPTY EnvironmentBlock, the loop never runs, so
+  // without this an empty block would collapse to a single null, which
+  // CreateProcessW rejects with ERROR_INVALID_PARAMETER when
+  // CREATE_UNICODE_ENVIRONMENT is set -- push a second one in that case so
+  // the block is a valid (if empty) list instead.
+  if (environment.empty())
+    environment.push_back(L'\0');
   environment.push_back(L'\0');
+  return environment;
+}
 
-  memset(&si, 0, sizeof si);
-  si.cb = sizeof si;
+} // namespace
 
-  // Note(sas): Not sure if we want DEBUG_ONLY_THIS_PROCESS here. Will need to
-  // check back later.
+ErrorCode ProcessSpawner::run(std::function<bool()> preExecAction) {
+  // preExecAction is a POSIX-only concept (it runs in the forked child right
+  // before exec, e.g. to call ptrace's traceme). CreateProcessW has no
+  // equivalent split point, so, as before this function did anything at all,
+  // it is intentionally not invoked here.
+  static_cast<void>(preExecAction);
+
+  if (_pid != 0 || _executablePath.empty())
+    return kErrorInvalidArgument;
+
+  bool anyExplicitRedirect =
+      std::any_of(_descriptors.begin(), _descriptors.end(),
+                  [](const RedirectDescriptor &d) {
+                    return d.mode != RedirectMode::unset;
+                  });
+
+  std::wstring commandLine =
+      BuildCommandLine(_executablePath, _arguments, _rawTrailingArgument);
+  std::vector<WCHAR> environment = BuildEnvironmentBlock(_environment);
+  // Callers that never called setEnvironment()/addEnvironment() at all
+  // (onLaunchDebugServer and onExecuteProgram, notably) want "inherit
+  // whatever ds2 itself is running under" -- pass nullptr in that case so
+  // the child inherits our environment, matching plain CreateProcessW
+  // behavior. That is deliberately not the same test as "_environment is
+  // empty": ProcessLaunchMixin::spawnProcess() always calls
+  // setEnvironment(), even when nothing has been accumulated in it, and an
+  // explicitly empty launch environment (matching what the POSIX execve
+  // path does with the same empty EnvironmentMap) must still reach
+  // CreateProcessW as a valid, empty block rather than collapse to "inherit
+  // ours". A genuinely empty block isn't the same as passing nullptr,
+  // either: many system components (Winsock among them) implicitly rely on
+  // standard environment variables (e.g. SystemRoot) being present, so
+  // BuildEnvironmentBlock() always produces a properly double-null-
+  // terminated (if otherwise empty) block rather than an empty vector.
+  LPVOID environmentArg =
+      _environmentSet ? static_cast<LPVOID>(environment.data()) : nullptr;
   std::wstring wideWorkingDirectory =
       ds2::Utils::NarrowToWideString(_workingDirectory);
-  BOOL result = CreateProcessW(
-      nullptr, commandLine.data(), nullptr, nullptr, false,
-      DEBUG_PROCESS | DEBUG_ONLY_THIS_PROCESS | CREATE_UNICODE_ENVIRONMENT,
-      environment.data(),
-      wideWorkingDirectory.empty() ? nullptr : wideWorkingDirectory.c_str(),
-      &si, &pi);
+  LPCWSTR workingDirectoryArg =
+      wideWorkingDirectory.empty() ? nullptr : wideWorkingDirectory.c_str();
 
-  if (!result)
+  DWORD creationFlags = CREATE_UNICODE_ENVIRONMENT;
+  if (_debugOnCreate)
+    creationFlags |= DEBUG_PROCESS | DEBUG_ONLY_THIS_PROCESS;
+
+  PROCESS_INFORMATION pi = {};
+
+  // Reproduce a plain, non-redirected CreateProcessW invocation with no
+  // inherited handles at all, exactly as this function has always done.
+  // This keeps Target::Windows::Process's debuggee-launch path (which never
+  // successfully configures redirection today -- DebugSessionImpl only
+  // calls the terminal/delegate redirection methods, which remain
+  // unimplemented stubs) completely unaffected by the redirection machinery
+  // below.
+  auto launchPlain = [&]() -> ErrorCode {
+    STARTUPINFOW si = {};
+    si.cb = sizeof(si);
+
+    BOOL result = ::CreateProcessW(
+        nullptr, &commandLine[0], nullptr, nullptr, /*bInheritHandles=*/FALSE,
+        creationFlags, environmentArg, workingDirectoryArg, &si, &pi);
+    if (!result)
+      return Platform::TranslateError();
+
+    _pid = pi.dwProcessId;
+    _handle = pi.hProcess;
+    _tid = pi.dwThreadId;
+    _threadHandle = pi.hThread;
+    return kSuccess;
+  };
+
+  if (!anyExplicitRedirect)
+    return launchPlain();
+
+  // At least one stream was explicitly redirected. Resolve each of the three
+  // standard streams to a handle the child will receive. Streams left
+  // RedirectMode::unset are resolved the same way as RedirectMode::console
+  // (pass the process's own current standard handle through), since
+  // STARTF_USESTDHANDLES applies to all three streams at once.
+  std::array<HANDLE, kStreamCount> stdHandles = {};
+  std::array<bool, kStreamCount> ownsStdHandle = {};
+  std::array<HANDLE, kStreamCount> parentPipeReadEnd = {};
+
+  auto cleanupHandles = [&]() {
+    for (size_t n = 0; n < kStreamCount; n++) {
+      if (ownsStdHandle[n] && stdHandles[n] != nullptr)
+        ::CloseHandle(stdHandles[n]);
+      if (parentPipeReadEnd[n] != nullptr)
+        ::CloseHandle(parentPipeReadEnd[n]);
+    }
+  };
+
+  for (size_t n = 0; n < kStreamCount; n++) {
+    RedirectDescriptor &d = _descriptors[n];
+    switch (d.mode) {
+    case RedirectMode::unset:
+    case RedirectMode::console: {
+      DWORD which = (n == Index(StreamIndex::input))    ? STD_INPUT_HANDLE
+                    : (n == Index(StreamIndex::output)) ? STD_OUTPUT_HANDLE
+                                                        : STD_ERROR_HANDLE;
+      HANDLE handle = ::GetStdHandle(which);
+      if (handle != nullptr && handle != INVALID_HANDLE_VALUE) {
+        ::SetHandleInformation(handle, HANDLE_FLAG_INHERIT,
+                               HANDLE_FLAG_INHERIT);
+        stdHandles[n] = handle;
+      }
+      break;
+    }
+
+    case RedirectMode::null: {
+      SECURITY_ATTRIBUTES sa = {sizeof(sa), nullptr, TRUE};
+      DWORD access =
+          (n == Index(StreamIndex::input)) ? GENERIC_READ : GENERIC_WRITE;
+      HANDLE handle =
+          ::CreateFileW(L"NUL", access, FILE_SHARE_READ | FILE_SHARE_WRITE, &sa,
+                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+      if (handle == INVALID_HANDLE_VALUE) {
+        DS2LOG(Warning, "RedirectMode::null n=%zu failed err=%#lx", n,
+               ::GetLastError());
+        cleanupHandles();
+        return Platform::TranslateError();
+      }
+      stdHandles[n] = handle;
+      ownsStdHandle[n] = true;
+      break;
+    }
+
+    case RedirectMode::file: {
+      // If stderr is being redirected to the exact same path as stdout,
+      // duplicate that already-open handle instead of opening the path a
+      // second time. Two independent handles opened separately (even with
+      // FILE_SHARE_WRITE) would each start writing from offset 0, silently
+      // clobbering whatever the other had already written, since neither
+      // handle's file position is aware of the other; sharing one handle
+      // means both streams append to wherever the current position
+      // actually is.
+      if (n == Index(StreamIndex::error) &&
+          _descriptors[Index(StreamIndex::output)].mode == RedirectMode::file &&
+          _descriptors[Index(StreamIndex::output)].path == d.path &&
+          stdHandles[Index(StreamIndex::output)] != nullptr) {
+        HANDLE dupHandle = nullptr;
+        if (!::DuplicateHandle(::GetCurrentProcess(),
+                               stdHandles[Index(StreamIndex::output)],
+                               ::GetCurrentProcess(), &dupHandle, 0, TRUE,
+                               DUPLICATE_SAME_ACCESS)) {
+          DS2LOG(Warning,
+                 "DuplicateHandle for shared stdout/stderr file failed "
+                 "err=%#lx",
+                 ::GetLastError());
+          cleanupHandles();
+          return Platform::TranslateError();
+        }
+        stdHandles[n] = dupHandle;
+        ownsStdHandle[n] = true;
+        break;
+      }
+
+      SECURITY_ATTRIBUTES sa = {sizeof(sa), nullptr, TRUE};
+      std::wstring widePath = ds2::Utils::NarrowToWideString(d.path);
+      // FILE_SHARE_WRITE on the write side isn't just for the stdout/stderr
+      // duplicate-handle case above (which never opens the path twice to
+      // begin with): it also covers, e.g., a client redirecting output to a
+      // file it or another handle already has open elsewhere.
+      HANDLE handle =
+          (n == Index(StreamIndex::input))
+              ? ::CreateFileW(widePath.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                              &sa, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+                              nullptr)
+              : ::CreateFileW(widePath.c_str(), GENERIC_WRITE,
+                              FILE_SHARE_READ | FILE_SHARE_WRITE, &sa,
+                              CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+      if (handle == INVALID_HANDLE_VALUE) {
+        DS2LOG(Warning, "RedirectMode::file n=%zu failed err=%#lx", n,
+               ::GetLastError());
+        cleanupHandles();
+        return Platform::TranslateError();
+      }
+      stdHandles[n] = handle;
+      ownsStdHandle[n] = true;
+      break;
+    }
+
+    case RedirectMode::buffer: {
+      // Only output/error support buffer redirection.
+      DS2ASSERT(n != Index(StreamIndex::input));
+      SECURITY_ATTRIBUTES sa = {sizeof(sa), nullptr, TRUE};
+      HANDLE readEnd, writeEnd;
+      if (!::CreatePipe(&readEnd, &writeEnd, &sa, 0)) {
+        DS2LOG(Warning, "CreatePipe n=%zu failed err=%#lx", n,
+               ::GetLastError());
+        cleanupHandles();
+        return Platform::TranslateError();
+      }
+      // Only the write end (handed to the child) should be inheritable;
+      // the read end is ours alone and must never leak into any other
+      // child ds2 spawns later.
+      ::SetHandleInformation(readEnd, HANDLE_FLAG_INHERIT, 0);
+
+      stdHandles[n] = writeEnd;
+      ownsStdHandle[n] = true;
+      parentPipeReadEnd[n] = readEnd;
+      break;
+    }
+    }
+  }
+
+  size_t resolvedHandleCount = 0;
+  for (size_t n = 0; n < kStreamCount; n++)
+    if (stdHandles[n] != nullptr)
+      ++resolvedHandleCount;
+
+  if (resolvedHandleCount == 0)
+    // Every requested stream resolved to "nothing to hand over" (e.g. an
+    // explicit Console redirect was requested, but this process itself has
+    // no console of its own to pass through). cleanupHandles() would be a
+    // no-op here since Null/File/Buffer always either produce an owned
+    // handle or return early on error above. There is nothing left to
+    // restrict inheritance to, so fall back to an ordinary invocation.
+    return launchPlain();
+
+  // Restrict handle inheritance to exactly the (up to three) handles we are
+  // handing to the child. Blanket bInheritHandles=TRUE would additionally
+  // duplicate every other inheritable handle this ds2 process currently
+  // holds (other clients' sockets, log files, ...) into the child, which is
+  // both a resource leak and, for buffered streams specifically, would
+  // duplicate our own pipe write end into the child, preventing us from
+  // ever observing EOF on it.
+  std::array<HANDLE, kStreamCount> handleList;
+  DWORD handleCount = 0;
+  for (size_t n = 0; n < kStreamCount; n++)
+    if (stdHandles[n] != nullptr)
+      handleList[handleCount++] = stdHandles[n];
+
+  SIZE_T attributeListSize = 0;
+  ::InitializeProcThreadAttributeList(nullptr, 1, 0, &attributeListSize);
+
+  std::vector<uint8_t> attributeListBuffer(attributeListSize);
+  auto attributeList = reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(
+      attributeListBuffer.data());
+
+  if (!::InitializeProcThreadAttributeList(attributeList, 1, 0,
+                                           &attributeListSize)) {
+    DS2LOG(Warning, "InitializeProcThreadAttributeList failed err=%#lx",
+           ::GetLastError());
+    cleanupHandles();
     return Platform::TranslateError();
+  }
+
+  if (!::UpdateProcThreadAttribute(
+          attributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+          handleList.data(), handleCount * sizeof(HANDLE), nullptr, nullptr)) {
+    DS2LOG(Warning, "UpdateProcThreadAttribute failed err=%#lx handleCount=%lu",
+           ::GetLastError(), handleCount);
+    ::DeleteProcThreadAttributeList(attributeList);
+    cleanupHandles();
+    return Platform::TranslateError();
+  }
+
+  STARTUPINFOEXW si = {};
+  si.StartupInfo.cb = sizeof(si);
+  si.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+  si.StartupInfo.hStdInput = stdHandles[Index(StreamIndex::input)];
+  si.StartupInfo.hStdOutput = stdHandles[Index(StreamIndex::output)];
+  si.StartupInfo.hStdError = stdHandles[Index(StreamIndex::error)];
+  si.lpAttributeList = attributeList;
+
+  BOOL result = ::CreateProcessW(
+      nullptr, &commandLine[0], nullptr, nullptr, /*bInheritHandles=*/TRUE,
+      creationFlags | EXTENDED_STARTUPINFO_PRESENT, environmentArg,
+      workingDirectoryArg, &si.StartupInfo, &pi);
+  if (!result)
+    DS2LOG(Warning, "CreateProcessW failed err=%#lx cmdline='%ls'",
+           ::GetLastError(), commandLine.c_str());
+
+  ::DeleteProcThreadAttributeList(attributeList);
+
+  // The child now has its own copy (if any) of every handle we handed it;
+  // close ours so a peer reading a buffered pipe can observe EOF, and so we
+  // don't otherwise leak these handles.
+  for (size_t n = 0; n < kStreamCount; n++)
+    if (ownsStdHandle[n] && stdHandles[n] != nullptr)
+      ::CloseHandle(stdHandles[n]);
+
+  if (!result) {
+    for (size_t n = 0; n < kStreamCount; n++)
+      if (parentPipeReadEnd[n] != nullptr)
+        ::CloseHandle(parentPipeReadEnd[n]);
+    return Platform::TranslateError();
+  }
 
   _pid = pi.dwProcessId;
   _handle = pi.hProcess;
-
   _tid = pi.dwThreadId;
   _threadHandle = pi.hThread;
 
+  for (size_t n = 0; n < kStreamCount; n++) {
+    if (parentPipeReadEnd[n] == nullptr)
+      continue;
+
+    _descriptors[n].handle = parentPipeReadEnd[n];
+    _redirectThreads[n] =
+        std::thread(&ProcessSpawner::redirectionThread, this, n);
+  }
+
   return kSuccess;
 }
+
+ErrorCode ProcessSpawner::wait() {
+  if (_pid == 0)
+    return kErrorProcessNotFound;
+
+  DWORD rc = ::WaitForSingleObject(_handle, INFINITE);
+  if (rc != WAIT_OBJECT_0)
+    return Platform::TranslateError();
+
+  DWORD exitCode = 0;
+  if (!::GetExitCodeProcess(_handle, &exitCode))
+    return Platform::TranslateError();
+
+  for (auto &thread : _redirectThreads)
+    if (thread.joinable())
+      thread.join();
+
+  ::CloseHandle(_threadHandle);
+  ::CloseHandle(_handle);
+  _handle = nullptr;
+  _threadHandle = nullptr;
+  _pid = 0;
+  _exitStatus = static_cast<int>(exitCode);
+
+  return kSuccess;
+}
+
+bool ProcessSpawner::isRunning() const {
+  if (_pid == 0)
+    return false;
+
+  return ::WaitForSingleObject(_handle, 0) == WAIT_TIMEOUT;
+}
+
+//
+// Redirector Thread
+//
+// One instance of this runs per RedirectMode::buffer stream (there can be up
+// to two -- output and error -- draining concurrently into the shared
+// _outputBuffer under a mutex).
+//
+void ProcessSpawner::redirectionThread(size_t index) {
+  HANDLE handle = _descriptors[index].handle;
+
+  for (;;) {
+    char buf[256];
+    DWORD nRead = 0;
+    if (!::ReadFile(handle, buf, sizeof(buf), &nRead, nullptr) || nRead == 0)
+      break;
+
+    std::lock_guard<std::mutex> lock(_outputBufferMutex);
+    _outputBuffer.insert(_outputBuffer.end(), &buf[0], &buf[nRead]);
+  }
+
+  ::CloseHandle(handle);
+  _descriptors[index].handle = nullptr;
+}
+
 } // namespace Host
 } // namespace ds2

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -542,6 +542,11 @@ ErrorCode Process::updateInfo() {
 }
 
 ds2::Target::Process *Process::Create(ProcessSpawner &spawner) {
+  // This is the only ProcessSpawner caller that goes on to pump
+  // WaitForDebugEvent/ContinueDebugEvent for the child (elsewhere in this
+  // file), so it is the only one that may ask to be started as a debuggee.
+  spawner.setDebugOnCreate(true);
+
   if (spawner.run() != kSuccess) {
     return nullptr;
   }

--- a/Sources/Utils/Log.cpp
+++ b/Sources/Utils/Log.cpp
@@ -97,6 +97,8 @@ void SetLogOutputFilename(std::string const &filename) {
   sOutputFilename = filename;
 }
 
+void SetLogOutputStream(FILE *stream) { sOutputStream = stream; }
+
 void SetLogColorsEnabled(bool enabled) { sColorsEnabled = enabled; }
 
 static void vLog(int level, char const *classname, char const *funcname,

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -39,7 +39,11 @@
 #if HAVE_TERMIOS_H
 #include <termios.h>
 #endif
-#if !defined(OS_WIN32)
+#if defined(OS_WIN32)
+#include "DebugServer2/Host/Windows/ExtraWrappers.h"
+#include <windows.h>
+#include <ws2tcpip.h>
+#else
 #include <unistd.h>
 #endif
 
@@ -508,7 +512,6 @@ static int GdbserverMain(int argc, char **argv) {
   return RunDebugServer(channel.get(), impl.get());
 }
 
-#if !defined(OS_WIN32)
 static int PlatformMain(int argc, char **argv) {
   DS2ASSERT(argv[1][0] == 'p');
 
@@ -569,9 +572,151 @@ static int SlaveMain(int argc, char **argv) {
 
   ds2::OptParse opts;
   AddSharedOptions(opts);
+#if defined(OS_WIN32)
+  // Internal use only: carries the numeric handle of the listening socket
+  // that "generation 1" below inherits into the relaunched "generation 2"
+  // process. Not meant to be used directly, hence hidden from --help.
+  opts.addOption(ds2::OptParse::stringOption, "child-socket", 'C',
+                 "internal use only", /*hidden=*/true);
+#endif
   opts.parse(argc, argv);
   HandleSharedOptions(opts);
 
+#if defined(OS_WIN32)
+  // ds2's Windows logging defaults to stdout (see Log.cpp), but generation
+  // 1 below prints its "port pid" status line to that same stdout for
+  // onLaunchDebugServer to parse -- and that pipe is the only stream it
+  // captures, so any --debug/--remote-debug DS2LOG output emitted before
+  // that line (e.g. CreateTCPSocket's "listening on ...") would corrupt it.
+  // Route logs to stderr instead, unless the user asked for a log file.
+  if (ds2::GetLogOutputFilename().empty())
+    ds2::SetLogOutputStream(stderr);
+
+  // There is no fork() on Windows. onLaunchDebugServer (which spawns
+  // whatever "ds2 slave ..." invocation reaches this function) blocks in
+  // ProcessSpawner::wait() until that process exits, then parses a "port
+  // pid" line from its captured stdout. So the process it spawns cannot
+  // itself be the one servicing the eventual gdb-remote connection -- it
+  // must print that line and exit quickly, while a separate, independently
+  // running process keeps listening on `port`.
+  //
+  // Generation 1 (what onLaunchDebugServer actually spawns) binds an
+  // ephemeral listening socket and relaunches itself as a detached process
+  // that inherits just that socket's handle, then reports its port and the
+  // detached process's pid and exits. Generation 2 (detected here via a
+  // non-empty --child-socket) accepts the one client generation 1 promised,
+  // and becomes its debug server.
+  const std::string &childSocketArg = opts.getString("child-socket");
+  if (!childSocketArg.empty()) {
+    // When in slave mode, output is suppressed but for standard error.
+    ::freopen("NUL", "r", stdin);
+    ::freopen("NUL", "w", stdout);
+
+    SOCKET listenHandle = static_cast<SOCKET>(std::stoull(childSocketArg));
+
+    struct sockaddr_storage ss;
+    int sslen = sizeof(ss);
+    SOCKET clientHandle = ::accept(
+        listenHandle, reinterpret_cast<struct sockaddr *>(&ss), &sslen);
+    ::closesocket(listenHandle);
+
+    if (clientHandle == INVALID_SOCKET)
+      DS2LOG(Fatal, "cannot accept slave connection: error %#x",
+             static_cast<unsigned>(::WSAGetLastError()));
+
+    auto client = std::make_unique<Socket>(clientHandle);
+    client->setNonBlocking();
+
+    SlaveSessionImpl impl;
+    return RunDebugServer(client.get(), &impl);
+  }
+
+  std::unique_ptr<Socket> server = CreateTCPSocket(gDefaultHost, "0", false);
+  std::string port = server->port();
+  SOCKET listenHandle = server->native_handle();
+
+  if (!::SetHandleInformation(reinterpret_cast<HANDLE>(listenHandle),
+                              HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT))
+    DS2LOG(Fatal, "cannot make listening socket inheritable: %#lx",
+           ::GetLastError());
+
+  ds2::StringCollection args;
+  args.push_back(Platform::GetSelfExecutablePath());
+  args.push_back("slave");
+  if (opts.getBool("debug"))
+    args.push_back("--debug");
+  if (opts.getBool("remote-debug"))
+    args.push_back("--remote-debug");
+  if (opts.getBool("no-colors"))
+    args.push_back("--no-colors");
+  if (!opts.getString("log-file").empty()) {
+    args.push_back("--log-file");
+    args.push_back(opts.getString("log-file"));
+  }
+  args.push_back("--child-socket");
+  args.push_back(ds2::Utils::ToString(static_cast<uint64_t>(listenHandle)));
+
+  std::wstring commandLine;
+  for (size_t i = 0; i < args.size(); ++i) {
+    if (i > 0)
+      commandLine += L' ';
+    commandLine += L'"';
+    for (auto const &ch : ds2::Utils::NarrowToWideString(args[i])) {
+      if (ch == L'"')
+        commandLine += L'\\';
+      commandLine += ch;
+    }
+    commandLine += L'"';
+  }
+
+  // Restrict handle inheritance to exactly the listening socket. Blanket
+  // bInheritHandles=TRUE would also duplicate our own captured-stdout pipe
+  // (onLaunchDebugServer's ProcessSpawner set that up to read our "port
+  // pid" line above) into generation 2, which then never closes -- so
+  // platform mode would never see EOF on it, hanging onLaunchDebugServer
+  // forever.
+  HANDLE handleList[] = {reinterpret_cast<HANDLE>(listenHandle)};
+
+  SIZE_T attributeListSize = 0;
+  ::InitializeProcThreadAttributeList(nullptr, 1, 0, &attributeListSize);
+
+  std::vector<uint8_t> attributeListBuffer(attributeListSize);
+  auto attributeList = reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(
+      attributeListBuffer.data());
+
+  if (!::InitializeProcThreadAttributeList(attributeList, 1, 0,
+                                           &attributeListSize) ||
+      !::UpdateProcThreadAttribute(
+          attributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, handleList,
+          sizeof(handleList), nullptr, nullptr))
+    DS2LOG(Fatal, "cannot set up handle inheritance for slave: %#lx",
+           ::GetLastError());
+
+  STARTUPINFOEXW si = {};
+  si.StartupInfo.cb = sizeof(si);
+  si.lpAttributeList = attributeList;
+
+  PROCESS_INFORMATION pi = {};
+  BOOL result = ::CreateProcessW(nullptr, &commandLine[0], nullptr, nullptr,
+                                 /*bInheritHandles=*/TRUE,
+                                 DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP |
+                                     EXTENDED_STARTUPINFO_PRESENT,
+                                 nullptr, nullptr, &si.StartupInfo, &pi);
+
+  ::DeleteProcThreadAttributeList(attributeList);
+
+  if (!result)
+    DS2LOG(Fatal, "cannot relaunch slave: %#lx", ::GetLastError());
+
+  ::CloseHandle(pi.hThread);
+  ::CloseHandle(pi.hProcess);
+
+  // Write to the standard output to let our parent know where we're
+  // listening.
+  ::fprintf(stdout, "%s %lu\n", port.c_str(), pi.dwProcessId);
+
+  return EXIT_SUCCESS;
+#else
   std::unique_ptr<Socket> server = CreateTCPSocket(gDefaultHost, "0", false);
   std::string port = server->port();
 
@@ -599,8 +744,8 @@ static int SlaveMain(int argc, char **argv) {
   }
 
   return EXIT_SUCCESS;
-}
 #endif
+}
 
 static int VersionMain(int argc, char **argv) {
   std::stringstream ss;
@@ -619,9 +764,7 @@ static int VersionMain(int argc, char **argv) {
 [[noreturn]] static void UsageDie(char const *argv0) {
   std::vector<std::pair<std::string, bool>> modes = {{"version", false},
                                                      {"gdbserver", true}};
-#if !defined(OS_WIN32)
   modes.emplace_back("platform", true);
-#endif
 
   ::fprintf(stderr, "Usage:\n");
   for (auto const &mode : modes) {
@@ -663,12 +806,10 @@ int main(int argc, char **argv) {
 #endif
 
   switch (argv[1][0]) {
-#if !defined(OS_WIN32)
   case 'p':
     return PlatformMain(argc, argv);
   case 's':
     return SlaveMain(argc, argv);
-#endif
   case 'v':
     return VersionMain(argc, argv);
   default:


### PR DESCRIPTION
Platform mode ("ds2 p --listen ...", LLDB's platform connect target) was compiled out on Windows entirely: PlatformMain/SlaveMain and the 'p'/'s' dispatch cases were wrapped in #if !defined(OS_WIN32), because SlaveMain relied on fork() to have onLaunchDebugServer's spawned "ds2 slave" process print "port pid" and exit quickly while a forked child kept listening for the eventual gdb-remote connection. Windows has no fork(), so SlaveMain now does a two-generation respawn instead: generation 1 binds the ephemeral listening socket and relaunches itself as a detached process inheriting only that socket's handle (via PROC_THREAD_ATTRIBUTE_HANDLE_LIST, not blanket handle inheritance -- that would also duplicate generation 1's own captured- stdout pipe into generation 2, which would then never close and hang onLaunchDebugServer forever), then prints the port/pid and exits; generation 2 accepts the one client and becomes the gdbserver.

Host::Windows::ProcessSpawner turned out to be a hard prerequisite: it had no stdio redirection, wait() was kErrorUnsupported, and run() unconditionally passed DEBUG_PROCESS | DEBUG_ONLY_THIS_PROCESS, which would freeze any platform-mode helper process forever since nothing pumps its debug events. It now implements Console/Null/File/Buffer redirection (handle inheritance scoped the same way as the SlaveMain respawn, and a reader thread per buffered stream since stdout+stderr draining through one multiplexed reader risks a pipe deadlock), a working wait()/isRunning(), and a setDebugOnCreate() toggle so only Target::Windows::Process's actual debuggee-launch path -- the one caller that goes on to pump WaitForDebugEvent/ContinueDebugEvent -- requests the debug-attach behavior.

Host::Windows::File was fully stubbed (every method returned kErrorUnsupported); it now implements open/pread/pwrite/fstat/chmod/ unlink/createDirectory/fileSize/fileMode, needed for platform mode's vFile:* file-transfer packets. Platform::TerminateProcess is implemented for the same reason (qKillSpawnedProcess). GetExecutableFileBuildID is left stubbed: onQueryModuleInfo already falls back to an MD5 hash without it, and PE CodeView parsing for a real module UUID is a large enough, separable piece of work to land on its own.

Verified end-to-end against a real MSVC build: a hand-crafted qLaunchGDBServer packet against "ds2 p" correctly spawns and reports a slave gdbserver that outlives the intermediate process and is genuinely reachable on the reported port.