### PR TITLE
GDBRemote: only commit to LLDB compat mode after a valid P/p suffix

### DIFF
--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -1038,18 +1038,19 @@ void Session::Handle_P(ProtocolInterpreter::Handler const &,
   if (*ptidptr == ';') {
     //
     // LLDB will send ;thread:tid when sending 'P' commands; pid
-    // is deduced from current process. Only LLDB sends this suffix, so
-    // treat it like QThreadSuffixSupported: a reliable signal to
-    // (re-)enter LLDB mode, since onWriteRegisterValue's register table
-    // choice depends on it.
-    if (_compatMode != kCompatibilityModeLLDB) {
-      DS2LOG(Debug, "entering LLDB compatibility mode");
-      _compatMode = kCompatibilityModeLLDB;
-    }
-
+    // is deduced from current process.
+    //
     if (!ptid.parse(ptidptr + 1, kCompatibilityModeLLDBThread)) {
       sendError(kErrorInvalidArgument);
       return;
+    }
+
+    // Only LLDB sends this suffix, so a successful parse is as reliable a
+    // signal as QThreadSuffixSupported: (re-)enter LLDB mode, since
+    // onWriteRegisterValue's register table choice depends on it.
+    if (_compatMode != kCompatibilityModeLLDB) {
+      DS2LOG(Debug, "entering LLDB compatibility mode");
+      _compatMode = kCompatibilityModeLLDB;
     }
   } else {
     //
@@ -1075,17 +1076,18 @@ void Session::Handle_p(ProtocolInterpreter::Handler const &,
   if (*eptr == ';') {
     //
     // LLDB will send ;thread:tid when sending 'p' commands; pid
-    // is deduced from current process. Only LLDB sends this suffix, so
-    // treat it the same way as QThreadSuffixSupported / Handle_P.
+    // is deduced from current process.
     //
-    if (_compatMode != kCompatibilityModeLLDB) {
-      DS2LOG(Debug, "entering LLDB compatibility mode");
-      _compatMode = kCompatibilityModeLLDB;
-    }
-
     if (!ptid.parse(eptr + 1, kCompatibilityModeLLDBThread)) {
       sendError(kErrorInvalidArgument);
       return;
+    }
+
+    // Only LLDB sends this suffix, so treat a successful parse the same
+    // way as QThreadSuffixSupported / Handle_P.
+    if (_compatMode != kCompatibilityModeLLDB) {
+      DS2LOG(Debug, "entering LLDB compatibility mode");
+      _compatMode = kCompatibilityModeLLDB;
     }
   } else {
     //

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -18,6 +18,7 @@
 #include "JSObjects/JSObjects.h"
 
 #include <cerrno>
+#include <cctype>
 #include <climits>
 #include <cstdlib>
 #include <cstring>
@@ -133,11 +134,22 @@ bool ProcessThreadId::parse(std::string const &string, CompatibilityMode mode) {
     break;
 
   case kCompatibilityModeLLDBThread:
-    if (std::strncmp(str, "thread:", 7) == 0) {
-      str += 7;
-      if (!parse_hex(str, new_tid))
-        return false;
-    }
+    if (std::strncmp(str, "thread:", 7) != 0)
+      return false;
+
+    str += 7;
+    if (!std::isxdigit(static_cast<unsigned char>(*str)))
+      return false;
+
+    if (!parse_hex(str, new_tid))
+      return false;
+
+    // LLDB can terminate the thread suffix with a trailing ';'.
+    if (*eptr == ';')
+      ++eptr;
+
+    if (*eptr != '\0')
+      return false;
     break;
 
   default:


### PR DESCRIPTION
Handle_P and Handle_p flipped _compatMode to kCompatibilityModeLLDB as soon as a ';' suffix was found, before ptid.parse validated it. A malformed suffix (e.g. P0=00;bad) would then hit the error path having already committed the mode change, leaving the session permanently in LLDB mode for the rest of the exchange. Parse first, flip mode only on success.