### PR TITLE
GDBRemote: encode Windows trace stops as SIGTRAP, not a fatal bug

### DIFF
--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -380,6 +380,7 @@ std::string StopInfo::encode(CompatibilityMode mode, bool listThreads) const {
     case StopInfo::kReasonAccessWatchpoint:
     case StopInfo::kReasonReadWatchpoint:
     case StopInfo::kReasonWriteWatchpoint:
+    case StopInfo::kReasonTrace:
       ss << 5; // SIGTRAP
       break;
     case StopInfo::kReasonMemoryError:


### PR DESCRIPTION
`StopInfo::encode()`'s Windows signal-number emulation switch handled `kReasonBreakpoint`, `kReasonAccessWatchpoint`, `kReasonRead`, `kReasonReadWriteWatchpoint`, but not `kReasonTrace`, falling through to a `DS2BUG("not implemented")` abort. `kReasonTrace` is exactly what a completed single-step reports as (`Sources/Target/Windows/Thread.cpp`'s `STATUS_SINGLE_STEP` handling), and stepping off a just-hit software breakpoint before reinserting it and continuing is the standard sequence LLDB uses every time it resumes past a breakpoint. The result: any continue past a breakpoint crashed ds2's debug session on Windows, right as it tried to report the step-off completion.

Map `kReasonTrace` to "SIGTRAP (5)", matching how POSIX platforms already report it: ptrace reports both breakpoint traps and completed single steps as SIGTRAP, so this mirrors the non-Windows encoding rather than inventing a new mapping.