### PR TITLE
GDBRemote: report the fault address for frame diagnose on Linux

### DIFF
--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 #if !defined(OS_WIN32)
@@ -173,6 +174,12 @@ struct StopInfo {
   Address watchpointAddress;
   int watchpointIndex;
 
+  // Set from siginfo_t's si_addr for memory-fault signals (SIGSEGV/SIGBUS).
+  // The GDB-remote stop-reply description field conventionally carries this
+  // as an "address=<hex>" substring, letting a client locate the faulting
+  // expression for post-mortem analysis.
+  std::optional<Address> fault;
+
   StopInfo() { clear(); }
 
   inline void clear() {
@@ -186,6 +193,7 @@ struct StopInfo {
     core = -1;
     watchpointAddress = 0;
     watchpointIndex = -1;
+    fault.reset();
   }
 };
 

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -290,6 +290,16 @@ std::string StopInfo::encodeInfo(CompatibilityMode mode,
 
   if (reason == StopInfo::kReasonSignalStop) {
     ss << ';' << "signal:" << signal;
+
+    // The stop description conventionally carries the fault address as an
+    // "address=<hex>" substring, so a client can locate the faulting
+    // expression; emit 0x so base-auto parsers decode the full value.
+    if (fault.has_value()) {
+      std::ostringstream desc;
+      desc << "address=0x" << std::hex
+           << static_cast<uint64_t>(fault.value());
+      ss << ';' << "description:" << ToHex(desc.str());
+    }
   }
 
   if (listThreads) {

--- a/Sources/Target/Linux/Thread.cpp
+++ b/Sources/Target/Linux/Thread.cpp
@@ -128,6 +128,14 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
         DS2LOG(Warning,
                "tid %d received signal %s from an external source (sender=%d)",
                tid(), strsignal(_stopInfo.signal), si.si_pid);
+
+      // For kernel-generated memory-fault signals, si_addr carries the
+      // faulting address. User-generated SIGSEGV/SIGBUS reports have
+      // si_code <= 0 and a different active union member.
+      if ((_stopInfo.signal == SIGSEGV || _stopInfo.signal == SIGBUS) &&
+          si.si_code > 0) {
+        _stopInfo.fault = reinterpret_cast<uint64_t>(si.si_addr);
+      }
     }
   } break;
 


### PR DESCRIPTION
Post-mortem crash analysis on the client side relies on the stop-reply description carrying the fault address as an "address=<hex>" substring for signal stops -- ds2 never sent one, so a memory-fault stop on a Linux/Android target carried no way to recover which address the faulting instruction touched.

Linux::Thread::updateStopInfo already fetches siginfo_t via ptrace for every stop; it just discarded si_addr afterwards. Capture it for SIGSEGV/SIGBUS specifically and encode it into the stop-reply's description field.