### PR TITLE
GDBRemote: make the D (detach) packet pid-aware

### DIFF
--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -1037,7 +1037,19 @@ ret:
   return error;
 }
 
-ErrorCode DebugSessionImplBase::onDetach(Session &, ProcessId, bool stopped) {
+ErrorCode DebugSessionImplBase::onDetach(Session &, ProcessId pid,
+                                         bool stopped) {
+  // The GDB-remote `D;<pid>` form lets a client detach a specific process
+  // by pid, e.g. the child of a fork()/vfork() we reported under the
+  // fork-events/vfork-events extension. We don't debug that child at all
+  // -- it was already detached and left to run free the moment we saw the
+  // fork -- so there's nothing to do beyond acknowledging the request; in
+  // particular we must *not* fall through to detaching our real (parent)
+  // process below.
+  if (pid != kAnyProcessId && pid != _process->pid()) {
+    return kSuccess;
+  }
+
   SoftwareBreakpointManager *bpm = _process->softwareBreakpointManager();
   if (bpm != nullptr) {
     bpm->clear();


### PR DESCRIPTION
onDetach ignored its pid argument entirely and always detached whatever _process happened to be, regardless of what pid the D packet actually named. This was invisible until now because ds2 only ever tracked one process -- but a multiprocess-aware client can send an explicit multiprocess-qualified `D;<child_pid>` to formally detach a specific process, such as the forked child from the fork/vfork stop the previous commits added, as part of its own bookkeeping for that event.

Before this fix, that packet would detach (and clear breakpoints on) the *parent* instead -- the pid was silently discarded -- which the D packet handler then reported as success, so the client believed the child was cleanly detached while the real, still-being-debugged process had just had its breakpoints wiped out from under it. Any expression evaluation or scripted stop-hook relying on a breakpoint landed in an inconsistent state immediately afterward (observed as spuriously interrupted expression evaluation across both fork() and vfork(), since both trigger this same path).

Now a `D;<pid>` for anything other than kAnyProcessId or our own pid is just acknowledged as a no-op: we already detached that child ourselves the moment we saw the fork, so there's nothing left to do, and critically we must not fall through to detaching the real process.