### PR TITLE
Enhance fork/vfork tracking

### DIFF
--- a/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
@@ -30,6 +30,20 @@ protected:
   Host::ProcessSpawner _spawner;
 
 protected:
+  enum Extension : uint32_t {
+    kExtensionForkEvents = (1u << 0),
+    kExtensionVForkEvents = (1u << 1),
+  };
+
+  // GDB-remote extension negotiation state from qSupported. Mutable because
+  // onQuerySupported is const, and applied to _process whenever it is
+  // (re)created, since negotiation and process creation can happen in either
+  // order.
+  mutable uint32_t _requestedExtensions = 0;
+  mutable uint32_t _supportedExtensions = 0;
+  mutable uint32_t _enabledExtensions = 0;
+
+protected:
   // a struct to help iterate over the thread list for onQueryThreadList
   mutable IterationState<ThreadId> _threadIterationState;
 
@@ -185,6 +199,8 @@ private:
   ErrorCode spawnProcess(StringCollection const &args,
                          EnvironmentBlock const &env);
   void appendOutput(char const *buf, size_t size);
+  void updateEnabledExtensions() const;
+  void applyEnabledExtensionsToProcess() const;
 };
 
 using DebugSessionImpl =

--- a/Headers/DebugServer2/Target/ProcessBase.h
+++ b/Headers/DebugServer2/Target/ProcessBase.h
@@ -30,6 +30,8 @@ public:
 protected:
   bool _terminated;
   uint32_t _flags;
+  bool _forkEventsEnabled = false;
+  bool _vforkEventsEnabled = false;
   ProcessId _pid;
   ProcessInfo _info;
   Address _loadBase;
@@ -48,6 +50,18 @@ public:
 
 public:
   inline bool attached() const { return (_flags & kFlagAttachedProcess) != 0; }
+
+public:
+  // Whether the client has negotiated support for the fork-events and
+  // vfork-events GDB-remote extensions (see qSupported); stop reasons tied
+  // to these extensions are only reported when the corresponding flag here
+  // is set.
+  inline bool forkEventsEnabled() const { return _forkEventsEnabled; }
+  inline bool vforkEventsEnabled() const { return _vforkEventsEnabled; }
+  inline void setForkEventsEnabled(bool fork, bool vfork) {
+    _forkEventsEnabled = fork;
+    _vforkEventsEnabled = vfork;
+  }
 
 public:
   inline Address const &loadBase() const { return _loadBase; }

--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -149,6 +149,9 @@ struct StopInfo {
     kReasonThreadSpawn,
     kReasonThreadEntry,
     kReasonThreadExit,
+    kReasonFork,
+    kReasonVFork,
+    kReasonVForkDone,
 #if defined(OS_WIN32)
     kReasonMemoryError,
     kReasonMemoryAlignment,
@@ -180,6 +183,12 @@ struct StopInfo {
   // expression for post-mortem analysis.
   std::optional<Address> fault;
 
+  // Set for kReasonFork/kReasonVFork: the pid/tid of the newly forked
+  // child. We don't support debugging the child (it's detached and left
+  // to run free), but the parent's stop still needs to report who it was,
+  // per the fork-events/vfork-events GDB-remote extension.
+  ProcessThreadId child;
+
   StopInfo() { clear(); }
 
   inline void clear() {
@@ -194,6 +203,7 @@ struct StopInfo {
     watchpointAddress = 0;
     watchpointIndex = -1;
     fault.reset();
+    child.clear();
   }
 };
 

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -43,6 +43,8 @@ DebugSessionImplBase::DebugSessionImplBase(int attachPid)
   _process = ds2::Target::Process::Attach(attachPid);
   if (_process == nullptr)
     DS2LOG(Fatal, "cannot attach to pid %d", attachPid);
+  else
+    applyEnabledExtensionsToProcess();
 }
 
 DebugSessionImplBase::DebugSessionImplBase()
@@ -73,9 +75,34 @@ ErrorCode DebugSessionImplBase::onInterrupt(Session &) {
 ErrorCode DebugSessionImplBase::onQuerySupported(
     Session &session, Feature::Collection const &remoteFeatures,
     Feature::Collection &localFeatures) const {
-  for (auto feature : remoteFeatures) {
-    DS2LOG(Debug, "gdb feature: %s", feature.name.c_str());
+  _requestedExtensions = 0;
+  _supportedExtensions = 0;
+
+  if (session.mode() != kCompatibilityModeLLDB) {
+#if defined(OS_LINUX)
+    _supportedExtensions |= kExtensionForkEvents | kExtensionVForkEvents;
+#endif
   }
+
+  for (auto const &feature : remoteFeatures) {
+    DS2LOG(Debug, "gdb feature: %s", feature.name.c_str());
+    if (feature.flag != Feature::kSupported)
+      continue;
+    if (feature.name == "fork-events") {
+      _requestedExtensions |= kExtensionForkEvents;
+    } else if (feature.name == "vfork-events") {
+      _requestedExtensions |= kExtensionVForkEvents;
+    }
+  }
+
+  updateEnabledExtensions();
+
+  // The fork-events/vfork-events extension is only in effect once both
+  // sides have agreed to it: we advertise support for it below regardless
+  // of what the client asked for, but we only actually report fork/vfork
+  // stops (see Target::Linux::Thread::updateStopInfo) once the client has
+  // requested the corresponding feature here as well.
+  applyEnabledExtensionsToProcess();
 
   // TODO PacketSize should be respected
   localFeatures.push_back(std::string("qEcho+"));
@@ -856,6 +883,7 @@ ErrorCode DebugSessionImplBase::onAttach(Session &session, ProcessId pid,
   if (_process == nullptr) {
     return kErrorProcessNotFound;
   }
+  applyEnabledExtensionsToProcess();
 
   return queryStopInfo(session, pid, stop);
 }
@@ -1046,13 +1074,17 @@ ErrorCode DebugSessionImplBase::onDetach(Session &, ProcessId pid,
                                          bool stopped) {
   // The GDB-remote `D;<pid>` form lets a client detach a specific process
   // by pid, e.g. the child of a fork()/vfork() we reported under the
-  // fork-events/vfork-events extension. We don't debug that child at all
-  // -- it was already detached and left to run free the moment we saw the
-  // fork -- so there's nothing to do beyond acknowledging the request; in
-  // particular we must *not* fall through to detaching our real (parent)
-  // process below.
+  // fork-events/vfork-events extension.
   if (pid != kAnyProcessId && pid != _process->pid()) {
+#if defined(OS_POSIX)
+    ErrorCode error = _process->ptrace().detach(pid);
+    if (error == kErrorProcessNotFound) {
+      return kSuccess;
+    }
+    return error;
+#else
     return kSuccess;
+#endif
   }
 
   SoftwareBreakpointManager *bpm = _process->softwareBreakpointManager();
@@ -1230,8 +1262,22 @@ ErrorCode DebugSessionImplBase::spawnProcess(StringCollection const &args,
     DS2LOG(Error, "cannot execute '%s'", args[0].c_str());
     return kErrorUnknown;
   }
+  applyEnabledExtensionsToProcess();
 
   return kSuccess;
+}
+
+void DebugSessionImplBase::updateEnabledExtensions() const {
+  _enabledExtensions = _requestedExtensions & _supportedExtensions;
+}
+
+void DebugSessionImplBase::applyEnabledExtensionsToProcess() const {
+  if (_process == nullptr)
+    return;
+
+  _process->setForkEventsEnabled(
+      (_enabledExtensions & kExtensionForkEvents) != 0,
+      (_enabledExtensions & kExtensionVForkEvents) != 0);
 }
 
 void DebugSessionImplBase::appendOutput(char const *buf, size_t size) {

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -101,6 +101,11 @@ ErrorCode DebugSessionImplBase::onQuerySupported(
     localFeatures.push_back(std::string("QProgramSignals+"));
     localFeatures.push_back(std::string("qXfer:siginfo:read+"));
     localFeatures.push_back(std::string("qXfer:siginfo:write+"));
+    // The forked child is detached and left to run free -- we don't support
+    // debugging it -- but we do detect the fork/vfork and report it as the
+    // corresponding stop reason (see Target::Linux::Thread::updateStopInfo).
+    localFeatures.push_back(std::string("fork-events+"));
+    localFeatures.push_back(std::string("vfork-events+"));
 #else
     localFeatures.push_back(std::string("QProgramSignals-"));
     localFeatures.push_back(std::string("qXfer:siginfo:read-"));

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -238,6 +238,15 @@ void StopInfo::reasonToString(std::string &key, std::string &val,
   case StopInfo::kReasonTrap:
     val = "trap";
     break;
+  case StopInfo::kReasonFork:
+    val = "fork";
+    break;
+  case StopInfo::kReasonVFork:
+    val = "vfork";
+    break;
+  case StopInfo::kReasonVForkDone:
+    val = "vforkdone";
+    break;
   case StopInfo::kReasonWriteWatchpoint:
   case StopInfo::kReasonReadWatchpoint:
   case StopInfo::kReasonAccessWatchpoint:
@@ -300,6 +309,20 @@ std::string StopInfo::encodeInfo(CompatibilityMode mode,
            << static_cast<uint64_t>(fault.value());
       ss << ';' << "description:" << ToHex(desc.str());
     }
+  }
+
+  if (reason == StopInfo::kReasonFork || reason == StopInfo::kReasonVFork) {
+    // The fork-events/vfork-events extension reports the forked child using
+    // the same GDB multiprocess-style "p<pid>.<tid>" format ProcessThreadId
+    // ::encode() already produces for kCompatibilityModeGDBMultiprocess.
+    auto [processId, threadId] = child;
+    ss << ';' << (reason == StopInfo::kReasonFork ? "fork" : "vfork") << ":p"
+       << HEX0 << static_cast<uint64_t>(processId) << '.' << HEX0
+       << static_cast<uint64_t>(threadId) << DEC;
+  }
+
+  if (reason == StopInfo::kReasonVForkDone) {
+    ss << ';' << "vforkdone:";
   }
 
   if (listThreads) {

--- a/Sources/Host/Linux/PTrace.cpp
+++ b/Sources/Host/Linux/PTrace.cpp
@@ -63,13 +63,19 @@ ErrorCode PTrace::traceThat(ProcessId pid) {
   if (pid <= 0)
     return kErrorInvalidArgument;
 
-  unsigned long traceFlags = PTRACE_O_TRACECLONE;
+  //
+  // Trace clone events to track threads; trace fork/vfork for the
+  // fork-events/vfork-events GDB-remote extension (the forked child is
+  // detached once its initial ptrace stop is collected, so it doesn't get
+  // consumed as a thread in the parent process); trace vfork-done so the
+  // parent's stop after the child execs/exits is also reported.
+  //
+  static constexpr unsigned long kTraceFlags =
+      PTRACE_O_TRACECLONE | PTRACE_O_TRACEFORK | PTRACE_O_TRACEVFORK |
+      PTRACE_O_TRACEVFORKDONE;
 
-  //
-  // Trace clone and exit events to track threads.
-  //
-  if (wrapPtrace(PTRACE_SETOPTIONS, pid, nullptr, traceFlags) < 0) {
-    DS2LOG(Warning, "unable to set PTRACE_O_TRACECLONE on pid %d, error=%s",
+  if (wrapPtrace(PTRACE_SETOPTIONS, pid, nullptr, kTraceFlags) < 0) {
+    DS2LOG(Warning, "unable to set ptrace trace options on pid %d, error=%s",
            pid, strerror(errno));
     return Platform::TranslateError();
   }

--- a/Sources/Target/Linux/Thread.cpp
+++ b/Sources/Target/Linux/Thread.cpp
@@ -59,9 +59,10 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
     //     Linux::Process::wait);
     // (1b) a thread traced with PTRACE_O_TRACEFORK/TRACEVFORK calls
     //      fork(2)/vfork(2); reported the same way as (1), but via
-    //      PTRACE_EVENT_FORK/VFORK instead of PTRACE_EVENT_CLONE, and
-    //      reported as a real stop per the fork-events/vfork-events
-    //      GDB-remote extension;
+    //      PTRACE_EVENT_FORK/VFORK instead of PTRACE_EVENT_CLONE. If the
+    //      client has negotiated the fork-events/vfork-events GDB-remote
+    //      extension, we report the fork/vfork itself as a real stop;
+    //      otherwise it's treated the same as (1);
     // (1c) a thread that vfork(2)'d resumes after its child calls execve(2)
     //      or _exit(2) and stops sharing memory with it, reported via
     //      PTRACE_EVENT_VFORK_DONE the same way as (1)/(1b);
@@ -92,7 +93,7 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
     static constexpr int kEventFork = SIGTRAP | (PTRACE_EVENT_FORK << 8);
     static constexpr int kEventVFork = SIGTRAP | (PTRACE_EVENT_VFORK << 8);
     static constexpr int kEventVForkDone =
-      SIGTRAP | (PTRACE_EVENT_VFORK_DONE << 8);
+        SIGTRAP | (PTRACE_EVENT_VFORK_DONE << 8);
     const int waitStatusHi = waitStatus >> 8;
 
     if (waitStatusHi == kEventClone) { // (1)
@@ -112,41 +113,56 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
       ErrorCode detachError = kSuccess;
       if (eventError == kSuccess) {
         int childStatus = 0;
-        pid_t waited = ::waitpid(static_cast<pid_t>(childPid), &childStatus,
-                                 __WALL);
+        pid_t waited;
+        do {
+          waited = ::waitpid(static_cast<pid_t>(childPid), &childStatus,
+                             __WALL);
+        } while (waited == -1 && errno == EINTR);
+
         if (waited != static_cast<pid_t>(childPid)) {
           DS2LOG(Warning,
                  "unable to collect initial stop for %s child pid %lu "
                  "(tid %d), errno=%s",
                  isVFork ? "vfork" : "fork", childPid, tid(),
                  Stringify::Errno(errno));
-          detachError = kErrorProcessNotFound;
+          return kErrorProcessNotFound;
         } else {
           detachError = process()->ptrace().detach(static_cast<ProcessId>(childPid));
-          if (detachError != kSuccess && detachError != kErrorProcessNotFound) {
+          if (detachError != kSuccess) {
             DS2LOG(Warning,
                    "unable to detach %s child pid %lu (tid %d), error=%d",
                    isVFork ? "vfork" : "fork", childPid, tid(), detachError);
+            return detachError;
           }
         }
       }
 
-      if (eventError == kSuccess &&
-          (detachError == kSuccess || detachError == kErrorProcessNotFound)) {
+      bool negotiated = isVFork ? process()->vforkEventsEnabled()
+                                 : process()->forkEventsEnabled();
+      if (eventError == kSuccess && detachError == kSuccess && negotiated) {
         _stopInfo.reason =
             isVFork ? StopInfo::kReasonVFork : StopInfo::kReasonFork;
         _stopInfo.child = ProcessThreadId(static_cast<ProcessId>(childPid),
                                           static_cast<ThreadId>(childPid));
+      } else {
+        // The client never negotiated the corresponding extension, or child
+        // detachment did not complete cleanly. Treat this the same as an
+        // ordinary clone event and resume transparently.
+        _stopInfo.event = StopInfo::kEventNone;
       }
     } else if (waitStatusHi == kEventVForkDone) { // (1c)
-      _stopInfo.reason = StopInfo::kReasonVForkDone;
+      if (process()->vforkEventsEnabled()) {
+        _stopInfo.reason = StopInfo::kReasonVForkDone;
 
-      unsigned long childPid = 0;
-      ErrorCode eventError =
-          process()->ptrace().getEventMessage(ptid, childPid);
-      if (eventError == kSuccess) {
-        _stopInfo.child = ProcessThreadId(static_cast<ProcessId>(childPid),
-                                          static_cast<ThreadId>(childPid));
+        unsigned long childPid = 0;
+        ErrorCode eventError =
+            process()->ptrace().getEventMessage(ptid, childPid);
+        if (eventError == kSuccess) {
+          _stopInfo.child = ProcessThreadId(static_cast<ProcessId>(childPid),
+                                            static_cast<ThreadId>(childPid));
+        }
+      } else {
+        _stopInfo.event = StopInfo::kEventNone;
       }
     } else if (si.si_code == SI_TKILL && si.si_pid == getpid()) { // (2)
       // The only signal we are supposed to send to the inferior is a SIGSTOP.

--- a/Sources/Target/Linux/Thread.cpp
+++ b/Sources/Target/Linux/Thread.cpp
@@ -80,7 +80,10 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
       return error;
     }
 
-    if (waitStatus >> 8 == (SIGTRAP | (PTRACE_EVENT_CLONE << 8))) { // (1)
+    static constexpr int kEventClone = SIGTRAP | (PTRACE_EVENT_CLONE << 8);
+    const int waitStatusHi = waitStatus >> 8;
+
+    if (waitStatusHi == kEventClone) { // (1)
       _stopInfo.event = StopInfo::kEventNone;
       _stopInfo.reason = StopInfo::kReasonThreadSpawn;
     } else if (si.si_code == SI_TKILL && si.si_pid == getpid()) { // (2)

--- a/Sources/Target/Linux/Thread.cpp
+++ b/Sources/Target/Linux/Thread.cpp
@@ -140,6 +140,14 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
       }
     } else if (waitStatusHi == kEventVForkDone) { // (1c)
       _stopInfo.reason = StopInfo::kReasonVForkDone;
+
+      unsigned long childPid = 0;
+      ErrorCode eventError =
+          process()->ptrace().getEventMessage(ptid, childPid);
+      if (eventError == kSuccess) {
+        _stopInfo.child = ProcessThreadId(static_cast<ProcessId>(childPid),
+                                          static_cast<ThreadId>(childPid));
+      }
     } else if (si.si_code == SI_TKILL && si.si_pid == getpid()) { // (2)
       // The only signal we are supposed to send to the inferior is a SIGSTOP.
       DS2ASSERT(_stopInfo.signal == SIGSTOP);

--- a/Sources/Target/Linux/Thread.cpp
+++ b/Sources/Target/Linux/Thread.cpp
@@ -57,6 +57,14 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
     //     WSTOPSIG(status) == SIGTRAP. We mark the thread stopped for no
     //     reason so it just gets restarted immediately (see
     //     Linux::Process::wait);
+    // (1b) a thread traced with PTRACE_O_TRACEFORK/TRACEVFORK calls
+    //      fork(2)/vfork(2); reported the same way as (1), but via
+    //      PTRACE_EVENT_FORK/VFORK instead of PTRACE_EVENT_CLONE, and
+    //      reported as a real stop per the fork-events/vfork-events
+    //      GDB-remote extension;
+    // (1c) a thread that vfork(2)'d resumes after its child calls execve(2)
+    //      or _exit(2) and stops sharing memory with it, reported via
+    //      PTRACE_EVENT_VFORK_DONE the same way as (1)/(1b);
     // (2) we sent the thread a SIGSTOP (with tkill(2)) to suspend it e.g.:
     //     when a thread hits a breakpoint, we have to stop every other thread,
     //     so we send each one of them a SIGSTOP with tkill(2). These other
@@ -81,11 +89,57 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
     }
 
     static constexpr int kEventClone = SIGTRAP | (PTRACE_EVENT_CLONE << 8);
+    static constexpr int kEventFork = SIGTRAP | (PTRACE_EVENT_FORK << 8);
+    static constexpr int kEventVFork = SIGTRAP | (PTRACE_EVENT_VFORK << 8);
+    static constexpr int kEventVForkDone =
+      SIGTRAP | (PTRACE_EVENT_VFORK_DONE << 8);
     const int waitStatusHi = waitStatus >> 8;
 
     if (waitStatusHi == kEventClone) { // (1)
       _stopInfo.event = StopInfo::kEventNone;
       _stopInfo.reason = StopInfo::kReasonThreadSpawn;
+    } else if (waitStatusHi == kEventFork || waitStatusHi == kEventVFork) { // (1b)
+      bool isVFork = waitStatusHi == kEventVFork;
+      unsigned long childPid = 0;
+      ErrorCode eventError =
+          process()->ptrace().getEventMessage(ptid, childPid);
+      if (eventError != kSuccess) {
+        DS2LOG(Warning,
+               "unable to get %s child pid for tid %d, errno=%s",
+               isVFork ? "vfork" : "fork", tid(), Stringify::Errno(errno));
+      }
+
+      ErrorCode detachError = kSuccess;
+      if (eventError == kSuccess) {
+        int childStatus = 0;
+        pid_t waited = ::waitpid(static_cast<pid_t>(childPid), &childStatus,
+                                 __WALL);
+        if (waited != static_cast<pid_t>(childPid)) {
+          DS2LOG(Warning,
+                 "unable to collect initial stop for %s child pid %lu "
+                 "(tid %d), errno=%s",
+                 isVFork ? "vfork" : "fork", childPid, tid(),
+                 Stringify::Errno(errno));
+          detachError = kErrorProcessNotFound;
+        } else {
+          detachError = process()->ptrace().detach(static_cast<ProcessId>(childPid));
+          if (detachError != kSuccess && detachError != kErrorProcessNotFound) {
+            DS2LOG(Warning,
+                   "unable to detach %s child pid %lu (tid %d), error=%d",
+                   isVFork ? "vfork" : "fork", childPid, tid(), detachError);
+          }
+        }
+      }
+
+      if (eventError == kSuccess &&
+          (detachError == kSuccess || detachError == kErrorProcessNotFound)) {
+        _stopInfo.reason =
+            isVFork ? StopInfo::kReasonVFork : StopInfo::kReasonFork;
+        _stopInfo.child = ProcessThreadId(static_cast<ProcessId>(childPid),
+                                          static_cast<ThreadId>(childPid));
+      }
+    } else if (waitStatusHi == kEventVForkDone) { // (1c)
+      _stopInfo.reason = StopInfo::kReasonVForkDone;
     } else if (si.si_code == SI_TKILL && si.si_pid == getpid()) { // (2)
       // The only signal we are supposed to send to the inferior is a SIGSTOP.
       DS2ASSERT(_stopInfo.signal == SIGSTOP);


### PR DESCRIPTION
This pull request adds support for the GDB remote protocol's fork-events and vfork-events extensions, allowing the server to report when a debugged process forks or vforks. The changes ensure that these events are only reported if both the server and client have negotiated support, and that the forked child is detached and left to run freely (not debugged). The implementation touches several core areas, including protocol negotiation, process/thread management, and stop reason reporting.

**GDB Remote Protocol Extensions: fork-events and vfork-events**

* Added tracking of whether the client has requested fork-events/vfork-events in `DebugSessionImplBase`, and ensured this is communicated to the `Process` instance during creation or attach/spawn. (`DebugSessionImpl.h`, `DebugSessionImpl.cpp`) [[1]](diffhunk://#diff-e8fab2c76110d9f17ad11038dd9ee3fd8f55ff7d8df6a990e300da889a8880ebR32-R39) [[2]](diffhunk://#diff-547de76c7e72e60bd50829344d622f8daabaa10439b07295fe4423de95f08d68R46-R47) [[3]](diffhunk://#diff-547de76c7e72e60bd50829344d622f8daabaa10439b07295fe4423de95f08d68R878) [[4]](diffhunk://#diff-547de76c7e72e60bd50829344d622f8daabaa10439b07295fe4423de95f08d68R1253) [[5]](diffhunk://#diff-547de76c7e72e60bd50829344d622f8daabaa10439b07295fe4423de95f08d68L76-R96)
* Advertised server support for fork-events and vfork-events in the qSupported response, and only report such events if the client has negotiated support. (`DebugSessionImpl.cpp`)

**Process and Thread Management**

* Added flags and accessors to `ProcessBase` to track whether fork-events/vfork-events reporting is enabled, and provided methods to set/query these flags. (`ProcessBase.h`) [[1]](diffhunk://#diff-7d3156695ae111a2263f743894e670c6343b6b513125202fda12aaba287ac020R33-R34) [[2]](diffhunk://#diff-7d3156695ae111a2263f743894e670c6343b6b513125202fda12aaba287ac020R54-R65)
* Updated Linux ptrace setup to trace fork/vfork/vfork-done events, in addition to clone, for proper event reporting. (`PTrace.cpp`)
* In `Thread::updateStopInfo`, handled new ptrace events for fork, vfork, and vfork-done: detaching the child process and reporting the event as a stop reason only if the client supports the extension. (`Thread.cpp`) [[1]](diffhunk://#diff-f3271c445ae13486dffb2c3865ed33d4a58c5627fa4123fe1f91a84278aad873R60-R70) [[2]](diffhunk://#diff-f3271c445ae13486dffb2c3865ed33d4a58c5627fa4123fe1f91a84278aad873R97-R132)

**Stop Reason Reporting**

* Added new stop reasons (`kReasonFork`, `kReasonVFork`, `kReasonVForkDone`) and associated fields to `StopInfo` for reporting fork/vfork events and the child process/thread IDs. (`Types.h`, `Structures.cpp`) [[1]](diffhunk://#diff-a7f47f4fc692c92edf116703e7ca1c559103194b0ccb621bb51a87991f854aa7R152-R154) [[2]](diffhunk://#diff-a7f47f4fc692c92edf116703e7ca1c559103194b0ccb621bb51a87991f854aa7R186-R192) [[3]](diffhunk://#diff-a7f47f4fc692c92edf116703e7ca1c559103194b0ccb621bb51a87991f854aa7R207-R208) [[4]](diffhunk://#diff-53bde76b10e86772d5736684448e8956dd8a611fa9ae03c246e46b9b2825c0c5R241-R249)
* Updated encoding and stringification of stop reasons to include fork/vfork information in the GDB remote protocol format. (`Structures.cpp`)

These changes collectively provide robust support for fork and vfork event reporting in the GDB remote debugging protocol, ensuring correct negotiation, event handling, and protocol compliance.