### PR TITLE
Enable extension track and negotation

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -181,6 +181,7 @@ filegroup(
         "Headers/DebugServer2/GDBRemote/Base.h",
         "Headers/DebugServer2/GDBRemote/DebugSessionImpl.h",
         "Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h",
+        "Headers/DebugServer2/GDBRemote/ExtensionSet.h",
         "Headers/DebugServer2/GDBRemote/Mixins/FileOperationsMixin.h",
         "Headers/DebugServer2/GDBRemote/Mixins/ProcessLaunchMixin.h",
         "Headers/DebugServer2/GDBRemote/PacketProcessor.h",

--- a/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "DebugServer2/GDBRemote/DummySessionDelegateImpl.h"
+#include "DebugServer2/GDBRemote/ExtensionSet.h"
 #include "DebugServer2/GDBRemote/Mixins/FileOperationsMixin.h"
 #include "DebugServer2/Host/ProcessSpawner.h"
 #include "DebugServer2/Target/Process.h"
@@ -30,18 +31,14 @@ protected:
   Host::ProcessSpawner _spawner;
 
 protected:
-  enum Extension : uint32_t {
-    kExtensionForkEvents = (1u << 0),
-    kExtensionVForkEvents = (1u << 1),
-  };
+  using ExtensionSet = GDBProtocol::ExtensionSet;
+  using Extension = ExtensionSet::Extension;
 
   // GDB-remote extension negotiation state from qSupported. Mutable because
   // onQuerySupported is const, and applied to _process whenever it is
   // (re)created, since negotiation and process creation can happen in either
   // order.
-  mutable uint32_t _requestedExtensions = 0;
-  mutable uint32_t _supportedExtensions = 0;
-  mutable uint32_t _enabledExtensions = 0;
+  mutable ExtensionSet _extensions;
 
 protected:
   // a struct to help iterate over the thread list for onQueryThreadList
@@ -199,7 +196,6 @@ private:
   ErrorCode spawnProcess(StringCollection const &args,
                          EnvironmentBlock const &env);
   void appendOutput(char const *buf, size_t size);
-  void updateEnabledExtensions() const;
   void applyEnabledExtensionsToProcess() const;
 };
 

--- a/Headers/DebugServer2/GDBRemote/ExtensionSet.h
+++ b/Headers/DebugServer2/GDBRemote/ExtensionSet.h
@@ -1,0 +1,162 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace ds2 {
+namespace GDBProtocol {
+
+class ExtensionSet {
+public:
+  struct AdvertisedFeature {
+    char const *name;
+    bool supported;
+  };
+
+  enum Extension : uint32_t {
+    kQEcho = (1u << 0),
+    kQStartNoAckMode = (1u << 1),
+    kQXferFeaturesRead = (1u << 2),
+    kQXferAuxvRead = (1u << 3),
+    kQXferLibrariesSVR4Read = (1u << 4),
+    kQXferLibrariesRead = (1u << 5),
+    kQListThreadsInStopReply = (1u << 6),
+    kQPassSignals = (1u << 7),
+    kBreakpointCommands = (1u << 8),
+    kMultiprocess = (1u << 9),
+    kQDisableRandomization = (1u << 10),
+    kQNonStop = (1u << 11),
+    kQProgramSignals = (1u << 12),
+    kQXferSiginfoRead = (1u << 13),
+    kQXferSiginfoWrite = (1u << 14),
+    kForkEvents = (1u << 15),
+    kVForkEvents = (1u << 16),
+    kQXferOSDataRead = (1u << 17),
+    kQXferThreadsRead = (1u << 18),
+  };
+
+public:
+  void reset() {
+    _requested = 0;
+    _supported = 0;
+    _enabled = 0;
+  }
+
+  void enable(Extension extension) {
+    _supported |= extension;
+    _enabled = _requested & _supported;
+  }
+
+  void disable(Extension extension) {
+    _supported &= ~static_cast<uint32_t>(extension);
+    _enabled = _requested & _supported;
+  }
+
+  void negotiate(std::string const &feature) {
+    Extension extension;
+    if (!find(feature, extension))
+      return;
+
+    _requested |= extension;
+    _enabled = _requested & _supported;
+  }
+
+  bool enabled(Extension extension) const {
+    return (_enabled & extension) != 0;
+  }
+
+  bool supported(Extension extension) const {
+    return (_supported & extension) != 0;
+  }
+
+  std::string feature(Extension extension) const {
+    return feature(extension, supported(extension));
+  }
+
+  std::string feature(Extension extension, bool state) const {
+    char const *featureName = this->name(extension);
+    if (featureName == nullptr)
+      return std::string();
+
+    std::string feature(featureName);
+    feature.push_back(state ? '+' : '-');
+    return feature;
+  }
+
+  AdvertisedFeature advertise(Extension extension,
+                              bool advertiseWhenUnsupported = false) const {
+    bool isSupported = supported(extension);
+    char const *featureName = name(extension);
+    if (featureName == nullptr || (!isSupported && !advertiseWhenUnsupported))
+      return {nullptr, false};
+
+    return {featureName, isSupported};
+  }
+
+  char const *name(Extension extension) const {
+    for (auto const &entry : kEntries) {
+      if (entry.extension == extension)
+        return entry.name;
+    }
+
+    return nullptr;
+  }
+
+private:
+  bool find(std::string const &feature, Extension &extension) const {
+    for (auto const &entry : kEntries) {
+      if (feature == entry.name) {
+        extension = entry.extension;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+private:
+  struct Entry {
+    Extension extension;
+    char const *name;
+  };
+
+  static constexpr Entry kEntries[] = {
+      {kQEcho, "qEcho"},
+      {kQStartNoAckMode, "QStartNoAckMode"},
+      {kQXferFeaturesRead, "qXfer:features:read"},
+      {kQXferAuxvRead, "qXfer:auxv:read"},
+      {kQXferLibrariesSVR4Read, "qXfer:libraries-svr4:read"},
+      {kQXferLibrariesRead, "qXfer:libraries:read"},
+      {kQListThreadsInStopReply, "QListThreadsInStopReply"},
+      {kQPassSignals, "QPassSignals"},
+      {kBreakpointCommands, "BreakpointCommands"},
+      {kMultiprocess, "multiprocess"},
+      {kQDisableRandomization, "QDisableRandomization"},
+      {kQNonStop, "QNonStop"},
+      {kQProgramSignals, "QProgramSignals"},
+      {kQXferSiginfoRead, "qXfer:siginfo:read"},
+      {kQXferSiginfoWrite, "qXfer:siginfo:write"},
+      {kForkEvents, "fork-events"},
+      {kVForkEvents, "vfork-events"},
+      {kQXferOSDataRead, "qXfer:osdata:read"},
+      {kQXferThreadsRead, "qXfer:threads:read"},
+  };
+
+private:
+  uint32_t _requested = 0;
+  uint32_t _supported = 0;
+  uint32_t _enabled = 0;
+};
+
+} // namespace GDBProtocol
+} // namespace ds2

--- a/Headers/DebugServer2/Target/ProcessBase.h
+++ b/Headers/DebugServer2/Target/ProcessBase.h
@@ -25,13 +25,16 @@ namespace Target {
 class ProcessBase {
 public:
   enum { kFlagNewProcess = (1 << 0), kFlagAttachedProcess = (1 << 1) };
+  enum Extension : uint32_t {
+    kExtensionForkEvents = (1u << 0),
+    kExtensionVForkEvents = (1u << 1),
+  };
   typedef std::map<ThreadId, Thread *> IdentityMap;
 
 protected:
   bool _terminated;
   uint32_t _flags;
-  bool _forkEventsEnabled = false;
-  bool _vforkEventsEnabled = false;
+  uint32_t _enabledExtensions = 0;
   ProcessId _pid;
   ProcessInfo _info;
   Address _loadBase;
@@ -56,11 +59,28 @@ public:
   // vfork-events GDB-remote extensions (see qSupported); stop reasons tied
   // to these extensions are only reported when the corresponding flag here
   // is set.
-  inline bool forkEventsEnabled() const { return _forkEventsEnabled; }
-  inline bool vforkEventsEnabled() const { return _vforkEventsEnabled; }
+  inline bool hasExtension(Extension extension) const {
+    return (_enabledExtensions & extension) != 0;
+  }
+  inline uint32_t enabledExtensions() const { return _enabledExtensions; }
+  inline bool forkEventsEnabled() const {
+    return hasExtension(kExtensionForkEvents);
+  }
+  inline bool vforkEventsEnabled() const {
+    return hasExtension(kExtensionVForkEvents);
+  }
+  inline void setEnabledExtensions(uint32_t extensions) {
+    _enabledExtensions = extensions;
+  }
   inline void setForkEventsEnabled(bool fork, bool vfork) {
-    _forkEventsEnabled = fork;
-    _vforkEventsEnabled = vfork;
+    uint32_t extensions = 0;
+    if (fork) {
+      extensions |= kExtensionForkEvents;
+    }
+    if (vfork) {
+      extensions |= kExtensionVForkEvents;
+    }
+    setEnabledExtensions(extensions);
   }
 
 public:

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -75,27 +75,60 @@ ErrorCode DebugSessionImplBase::onInterrupt(Session &) {
 ErrorCode DebugSessionImplBase::onQuerySupported(
     Session &session, Feature::Collection const &remoteFeatures,
     Feature::Collection &localFeatures) const {
-  _requestedExtensions = 0;
-  _supportedExtensions = 0;
+  _extensions.reset();
 
-  if (session.mode() != kCompatibilityModeLLDB) {
+  bool isLLDB = (session.mode() == kCompatibilityModeLLDB);
+
+  auto supported = [this](Extension extension) { _extensions.enable(extension); };
+
+  static constexpr Extension kAlwaysSupported[] = {
+      ExtensionSet::kQEcho,
+      ExtensionSet::kQStartNoAckMode,
+      ExtensionSet::kQXferFeaturesRead,
+      ExtensionSet::kQListThreadsInStopReply,
+      ExtensionSet::kQPassSignals,
+  };
+  for (Extension extension : kAlwaysSupported)
+    supported(extension);
+
+#if defined(OS_LINUX) || defined(OS_FREEBSD)
+  supported(ExtensionSet::kQXferAuxvRead);
+  supported(ExtensionSet::kQXferLibrariesSVR4Read);
+#elif defined(OS_WIN32)
+  supported(ExtensionSet::kQXferLibrariesRead);
+#endif
+
+  if (!isLLDB) {
+    static constexpr Extension kNonLLDBSupported[] = {
+        ExtensionSet::kBreakpointCommands,
+        ExtensionSet::kMultiprocess,
+        ExtensionSet::kQDisableRandomization,
+        ExtensionSet::kQNonStop,
+        ExtensionSet::kQXferOSDataRead,
+        ExtensionSet::kQXferThreadsRead,
+    };
+    for (Extension extension : kNonLLDBSupported)
+      supported(extension);
+
 #if defined(OS_LINUX)
-    _supportedExtensions |= kExtensionForkEvents | kExtensionVForkEvents;
+    static constexpr Extension kLinuxOnlySupported[] = {
+        ExtensionSet::kQProgramSignals,
+        ExtensionSet::kQXferSiginfoRead,
+        ExtensionSet::kQXferSiginfoWrite,
+        ExtensionSet::kForkEvents,
+        ExtensionSet::kVForkEvents,
+    };
+    for (Extension extension : kLinuxOnlySupported)
+      supported(extension);
 #endif
   }
 
-  for (auto const &feature : remoteFeatures) {
-    DS2LOG(Debug, "gdb feature: %s", feature.name.c_str());
-    if (feature.flag != Feature::kSupported)
+  for (auto const &remoteFeature : remoteFeatures) {
+    DS2LOG(Debug, "gdb feature: %s", remoteFeature.name.c_str());
+    if (remoteFeature.flag != Feature::kSupported)
       continue;
-    if (feature.name == "fork-events") {
-      _requestedExtensions |= kExtensionForkEvents;
-    } else if (feature.name == "vfork-events") {
-      _requestedExtensions |= kExtensionVForkEvents;
-    }
+    _extensions.negotiate(remoteFeature.name);
   }
-
-  updateEnabledExtensions();
 
   // The fork-events/vfork-events extension is only in effect once both
   // sides have agreed to it: we advertise support for it below regardless
@@ -104,49 +137,93 @@ ErrorCode DebugSessionImplBase::onQuerySupported(
   // requested the corresponding feature here as well.
   applyEnabledExtensionsToProcess();
 
-  // TODO PacketSize should be respected
-  localFeatures.push_back(std::string("qEcho+"));
-  localFeatures.push_back(std::string("PacketSize=3fff"));
-  localFeatures.push_back(std::string("QStartNoAckMode+"));
-  localFeatures.push_back(std::string("qXfer:features:read+"));
-#if defined(OS_LINUX) || defined(OS_FREEBSD)
-  localFeatures.push_back(std::string("qXfer:auxv:read+"));
-  localFeatures.push_back(std::string("qXfer:libraries-svr4:read+"));
-#elif defined(OS_WIN32)
-  localFeatures.push_back(std::string("qXfer:libraries:read+"));
-#endif
-  localFeatures.push_back(std::string("QListThreadsInStopReply+"));
-  localFeatures.push_back(std::string("QPassSignals+"));
+  localFeatures.reserve(localFeatures.size() + (isLLDB ? 8u : 26u));
 
-  if (session.mode() != kCompatibilityModeLLDB) {
-    localFeatures.push_back(std::string("ConditionalBreakpoints-"));
-    localFeatures.push_back(std::string("BreakpointCommands+"));
-    localFeatures.push_back(std::string("multiprocess+"));
-    localFeatures.push_back(std::string("QDisableRandomization+"));
-    localFeatures.push_back(std::string("QNonStop+"));
-#if defined(OS_LINUX)
-    localFeatures.push_back(std::string("QProgramSignals+"));
-    localFeatures.push_back(std::string("qXfer:siginfo:read+"));
-    localFeatures.push_back(std::string("qXfer:siginfo:write+"));
+  auto addFeature = [&localFeatures](char const *name, Feature::Flag flag,
+                                     char const *value = nullptr) {
+    Feature feature;
+    feature.name = name;
+    feature.flag = flag;
+    if (value != nullptr)
+      feature.value = value;
+    localFeatures.push_back(feature);
+  };
+
+  auto enable =
+      [this, &addFeature](Extension extension,
+                             bool advertiseWhenUnsupported = false) {
+        ExtensionSet::AdvertisedFeature feature =
+            _extensions.advertise(extension, advertiseWhenUnsupported);
+        if (feature.name == nullptr)
+          return;
+
+        addFeature(feature.name,
+                   feature.supported ? Feature::kSupported
+                                     : Feature::kNotSupported);
+      };
+
+  // TODO PacketSize should be respected
+  static constexpr Extension kAlwaysAdvertised[] = {
+      ExtensionSet::kQEcho,
+      ExtensionSet::kQStartNoAckMode,
+      ExtensionSet::kQXferFeaturesRead,
+      ExtensionSet::kQXferAuxvRead,
+      ExtensionSet::kQXferLibrariesSVR4Read,
+      ExtensionSet::kQXferLibrariesRead,
+      ExtensionSet::kQListThreadsInStopReply,
+      ExtensionSet::kQPassSignals,
+  };
+  enable(kAlwaysAdvertised[0]);
+  addFeature("PacketSize", Feature::kSupported, "3fff");
+  for (size_t index = 1; index < sizeof(kAlwaysAdvertised) / sizeof(*kAlwaysAdvertised);
+       ++index) {
+    enable(kAlwaysAdvertised[index]);
+  }
+
+  if (!isLLDB) {
+    addFeature("ConditionalBreakpoints", Feature::kNotSupported);
+
+    static constexpr Extension kNonLLDBAdvertised[] = {
+        ExtensionSet::kBreakpointCommands,
+        ExtensionSet::kMultiprocess,
+        ExtensionSet::kQDisableRandomization,
+        ExtensionSet::kQNonStop,
+    };
+    for (Extension extension : kNonLLDBAdvertised)
+      enable(extension);
+
+    static constexpr Extension kAdvertisedWithUnsupportedFallback[] = {
+        ExtensionSet::kQProgramSignals,
+        ExtensionSet::kQXferSiginfoRead,
+        ExtensionSet::kQXferSiginfoWrite,
+    };
+    for (Extension extension : kAdvertisedWithUnsupportedFallback)
+      enable(extension, true);
+
     // The forked child is detached and left to run free -- we don't support
     // debugging it -- but we do detect the fork/vfork and report it as the
     // corresponding stop reason (see Target::Linux::Thread::updateStopInfo).
-    localFeatures.push_back(std::string("fork-events+"));
-    localFeatures.push_back(std::string("vfork-events+"));
-#else
-    localFeatures.push_back(std::string("QProgramSignals-"));
-    localFeatures.push_back(std::string("qXfer:siginfo:read-"));
-    localFeatures.push_back(std::string("qXfer:siginfo:write-"));
-#endif
-    localFeatures.push_back(std::string("qXfer:osdata:read+"));
-    localFeatures.push_back(std::string("qXfer:threads:read+"));
+    static constexpr Extension kForkEventExtensions[] = {
+        ExtensionSet::kForkEvents,
+        ExtensionSet::kVForkEvents,
+    };
+    for (Extension extension : kForkEventExtensions)
+      enable(extension, true);
+
+    static constexpr Extension kProcessInfoAdvertised[] = {
+        ExtensionSet::kQXferOSDataRead,
+        ExtensionSet::kQXferThreadsRead,
+    };
+    for (Extension extension : kProcessInfoAdvertised)
+      enable(extension);
+
     // Disable unsupported tracepoints
-    localFeatures.push_back(std::string("Qbtrace:bts-"));
-    localFeatures.push_back(std::string("Qbtrace:off-"));
-    localFeatures.push_back(std::string("tracenz-"));
-    localFeatures.push_back(std::string("ConditionalTracepoints-"));
-    localFeatures.push_back(std::string("TracepointSource-"));
-    localFeatures.push_back(std::string("EnableDisableTracepoints-"));
+    addFeature("Qbtrace:bts", Feature::kNotSupported);
+    addFeature("Qbtrace:off", Feature::kNotSupported);
+    addFeature("tracenz", Feature::kNotSupported);
+    addFeature("ConditionalTracepoints", Feature::kNotSupported);
+    addFeature("TracepointSource", Feature::kNotSupported);
+    addFeature("EnableDisableTracepoints", Feature::kNotSupported);
   }
 
   return kSuccess;
@@ -1267,19 +1344,15 @@ ErrorCode DebugSessionImplBase::spawnProcess(StringCollection const &args,
   return kSuccess;
 }
 
-void DebugSessionImplBase::updateEnabledExtensions() const {
-  _enabledExtensions = _requestedExtensions & _supportedExtensions;
-}
-
 void DebugSessionImplBase::applyEnabledExtensionsToProcess() const {
   if (_process == nullptr)
     return;
 
   uint32_t processExtensions = 0;
-  if ((_enabledExtensions & kExtensionForkEvents) != 0) {
+  if (_extensions.enabled(ExtensionSet::kForkEvents)) {
     processExtensions |= Target::ProcessBase::kExtensionForkEvents;
   }
-  if ((_enabledExtensions & kExtensionVForkEvents) != 0) {
+  if (_extensions.enabled(ExtensionSet::kVForkEvents)) {
     processExtensions |= Target::ProcessBase::kExtensionVForkEvents;
   }
 

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -1275,9 +1275,15 @@ void DebugSessionImplBase::applyEnabledExtensionsToProcess() const {
   if (_process == nullptr)
     return;
 
-  _process->setForkEventsEnabled(
-      (_enabledExtensions & kExtensionForkEvents) != 0,
-      (_enabledExtensions & kExtensionVForkEvents) != 0);
+  uint32_t processExtensions = 0;
+  if ((_enabledExtensions & kExtensionForkEvents) != 0) {
+    processExtensions |= Target::ProcessBase::kExtensionForkEvents;
+  }
+  if ((_enabledExtensions & kExtensionVForkEvents) != 0) {
+    processExtensions |= Target::ProcessBase::kExtensionVForkEvents;
+  }
+
+  _process->setEnabledExtensions(processExtensions);
 }
 
 void DebugSessionImplBase::appendOutput(char const *buf, size_t size) {


### PR DESCRIPTION
This pull request refactors how GDB-remote protocol extensions are negotiated, enabled, and managed in the codebase. The changes introduce a new `ExtensionSet` class to encapsulate extension handling, replace scattered bitmask logic with this new abstraction, and update both the session and process extension management to use it. This results in cleaner, more maintainable code and sets the stage for easier extension of supported features in the future.

**Extension negotiation and management refactor:**

* Introduced the new `GDBProtocol::ExtensionSet` class (`Headers/DebugServer2/GDBRemote/ExtensionSet.h`) to encapsulate extension negotiation, enablement, and advertisement, replacing manual bitmask handling.
* Updated `DebugSessionImplBase` to use `ExtensionSet` for all extension-related state, replacing the previous `_requestedExtensions`, `_supportedExtensions`, and `_enabledExtensions` members with a single `_extensions` member. [[1]](diffhunk://#diff-e8fab2c76110d9f17ad11038dd9ee3fd8f55ff7d8df6a990e300da889a8880ebL33-R41) [[2]](diffhunk://#diff-e8fab2c76110d9f17ad11038dd9ee3fd8f55ff7d8df6a990e300da889a8880ebR14) [[3]](diffhunk://#diff-3053677e4333a96b20ed76c662bca07fb2e1ce059479170139209356787da09cR184)
* Rewrote the extension negotiation logic in `onQuerySupported` to use the new `ExtensionSet` methods for enabling, disabling, and advertising features, greatly simplifying and clarifying the code.

**Process extension handling improvements:**

* Refactored `Target::ProcessBase` to replace individual fork/vfork event flags with a general `_enabledExtensions` bitmask and added methods for managing and querying enabled extensions. [[1]](diffhunk://#diff-7d3156695ae111a2263f743894e670c6343b6b513125202fda12aaba287ac020R28-R37) [[2]](diffhunk://#diff-7d3156695ae111a2263f743894e670c6343b6b513125202fda12aaba287ac020L59-R83)
* Updated the logic in `applyEnabledExtensionsToProcess` to set process extensions using the new abstraction, ensuring the process accurately reflects negotiated extension state.

**Code cleanup:**

* Removed obsolete methods and bitmask logic, such as `updateEnabledExtensions`, since this logic is now handled by `ExtensionSet`. [[1]](diffhunk://#diff-e8fab2c76110d9f17ad11038dd9ee3fd8f55ff7d8df6a990e300da889a8880ebL202) [[2]](diffhunk://#diff-547de76c7e72e60bd50829344d622f8daabaa10439b07295fe4423de95f08d68L1270-R1303)