### PR TITLE
GHA: split build and test into separate workflows with per-arch rollup

### DIFF
--- a/.github/actions/run-lldb-tests/action.yml
+++ b/.github/actions/run-lldb-tests/action.yml
@@ -74,6 +74,13 @@ runs:
 
         excluded_dir="${{ inputs.ds2-repo-path }}/Support/Testing/Excluded"
 
+        # dotest's LLDBTestResult.addSkip() unconditionally writes one
+        # "UNSUPPORTED: LLDB (...) :: ..." line per skipped test, regardless
+        # of -v -- with thousands of tests, most of them skipped for this
+        # platform/arch, that drowns out the PASS/FAIL lines that actually
+        # matter. Filter it out here rather than patching upstream dotest.
+        # `pipefail` (set above) keeps the step's exit status tied to
+        # lldb-dotest itself, not to grep.
         "${{ inputs.python }}" "${{ inputs.lldb-dotest-path }}" \
           --out-of-tree-debugserver \
           --arch "${{ inputs.arch }}" \
@@ -84,4 +91,4 @@ runs:
           --excluded "$excluded_dir/ds2/${{ inputs.platform }}-${{ inputs.arch }}.excluded" \
           --excluded "$excluded_dir/upstream/non-debugserver-tests.excluded" \
           -v \
-          ${{ inputs.test-subdirs }}
+          ${{ inputs.test-subdirs }} 2>&1 | grep -v '^UNSUPPORTED: LLDB '

--- a/.github/actions/run-lldb-tests/action.yml
+++ b/.github/actions/run-lldb-tests/action.yml
@@ -1,0 +1,87 @@
+name: Run lldb tests against ds2
+description: >-
+  Starts ds2 in platform mode and runs the lldb-dotest suite against it,
+  applying the standard upstream/ds2/non-debugserver exclusion lists for
+  the given platform and architecture.
+
+inputs:
+  ds2-path:
+    description: Path to the ds2 (platform mode) executable
+    required: true
+  lldb-dotest-path:
+    description: Path to the lldb-dotest wrapper script
+    required: true
+  ds2-repo-path:
+    description: Path to the checked-out ds2 repository
+    required: true
+  arch:
+    description: Architecture to pass to dotest.py's --arch (e.g. x86_64, i686, aarch64)
+    required: true
+  platform:
+    description: >-
+      Short platform name used both to build the lldb platform plugin name
+      (remote-<platform>) and to locate the exclusion lists
+      (Support/Testing/Excluded/{upstream,ds2}/<platform>-<arch>.excluded)
+    required: true
+  working-dir:
+    description: Remote platform working directory
+    required: true
+  test-subdirs:
+    description: Space-separated list of test subdirectories to run
+    required: true
+  listen-port:
+    description: TCP port ds2's platform server listens on
+    default: "5432"
+  python:
+    description: Python interpreter used to invoke the lldb-dotest wrapper script
+    default: "python3"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+
+        mkdir -p "${{ inputs.working-dir }}"
+
+        # --daemonize is POSIX-only (Sources/main.cpp gates it on OS_POSIX, so
+        # Windows' ds2 rejects it as unrecognized); background the process at
+        # the shell level instead, which works the same way on every platform
+        # this action runs on.
+        "${{ inputs.ds2-path }}" platform --server --listen localhost:${{ inputs.listen-port }} &
+
+        # Backgrounding returns immediately, before the socket is necessarily
+        # listening, so poll for it rather than racing lldb-dotest's connect
+        # against ds2's startup. Poll with the same Python interpreter used
+        # to run the tests rather than bash's /dev/tcp: Git for Windows'
+        # bundled bash isn't built with net redirections, so /dev/tcp there
+        # silently fails every iteration and the loop always runs out its
+        # full timeout instead of detecting readiness.
+        "${{ inputs.python }}" - <<'PY'
+        import socket
+        import sys
+        import time
+
+        for _ in range(50):
+            try:
+                with socket.create_connection(("localhost", ${{ inputs.listen-port }}), timeout=0.2):
+                    sys.exit(0)
+            except OSError:
+                time.sleep(0.2)
+        sys.exit(0)  # best-effort: fall through and let lldb-dotest's own connect report the real error
+        PY
+
+        excluded_dir="${{ inputs.ds2-repo-path }}/Support/Testing/Excluded"
+
+        "${{ inputs.python }}" "${{ inputs.lldb-dotest-path }}" \
+          --out-of-tree-debugserver \
+          --arch "${{ inputs.arch }}" \
+          --platform-name "remote-${{ inputs.platform }}" \
+          --platform-url "connect://localhost:${{ inputs.listen-port }}" \
+          --platform-working-dir "${{ inputs.working-dir }}" \
+          --excluded "$excluded_dir/upstream/${{ inputs.platform }}-${{ inputs.arch }}.excluded" \
+          --excluded "$excluded_dir/ds2/${{ inputs.platform }}-${{ inputs.arch }}.excluded" \
+          --excluded "$excluded_dir/upstream/non-debugserver-tests.excluded" \
+          -v \
+          ${{ inputs.test-subdirs }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,17 @@ env:
 
 jobs:
 
+  # `with:` on a `uses: ./workflow.yml` call can't see the top-level `env:`
+  # context (only github/needs/vars/etc. are available there) -- relay
+  # LLVM_REF through a job output instead of duplicating it, so it stays a
+  # single source of truth.
+  vars:
+    runs-on: ubuntu-latest
+    outputs:
+      llvm-ref: ${{ env.LLVM_REF }}
+    steps:
+      - run: 'true'
+
   windows_tools:
     runs-on: windows-latest
 
@@ -448,295 +459,20 @@ jobs:
           name: llvm-${{ runner.os }}-${{ runner.arch }}
           path: ${{ github.workspace }}/BinaryCache/llvm.tar
 
+  # Each platform's tests kick off as soon as that platform's own build (and
+  # the lldb test-runner build they share) finish, independent of every
+  # other platform still building -- fan out in parallel rather than
+  # waiting for every build job to complete before any test starts.
   test-linux:
-    needs: [linux, build-lldb-linux]
-    runs-on: ${{ matrix.runner }}
+    needs: [vars, linux, build-lldb-linux]
+    uses: ./.github/workflows/test.yml
+    with:
+      llvm-ref: ${{ needs.vars.outputs.llvm-ref }}
+      platform: linux
 
-    name: Test Linux ${{ matrix.arch }} ${{ matrix.test-category }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - test-category: misc
-            runner: ubuntu-latest
-            arch: i686
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/api
-              SourceCache/llvm/lldb/test/API/lang
-              SourceCache/llvm/lldb/test/API/linux
-              SourceCache/llvm/lldb/test/API/tools
-              SourceCache/llvm/lldb/test/API/sanity
-              SourceCache/llvm/lldb/test/API/types
-          - test-category: misc
-            runner: ubuntu-latest
-            arch: x86_64
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/api
-              SourceCache/llvm/lldb/test/API/lang
-              SourceCache/llvm/lldb/test/API/linux
-              SourceCache/llvm/lldb/test/API/tools
-              SourceCache/llvm/lldb/test/API/sanity
-              SourceCache/llvm/lldb/test/API/types
-          - test-category: misc
-            runner: ubuntu-24.04-arm
-            arch: aarch64
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/api
-              SourceCache/llvm/lldb/test/API/lang
-              SourceCache/llvm/lldb/test/API/linux
-              SourceCache/llvm/lldb/test/API/tools
-              SourceCache/llvm/lldb/test/API/sanity
-              SourceCache/llvm/lldb/test/API/types
-
-          - test-category: commands
-            runner: ubuntu-latest
-            arch: x86_64
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/commands
-          - test-category: commands
-            runner: ubuntu-latest
-            arch: i686
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/commands
-          - test-category: commands
-            runner: ubuntu-24.04-arm
-            arch: aarch64
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/commands
-
-          - test-category: Python API
-            runner: ubuntu-latest
-            arch: x86_64
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/python_api
-          - test-category: Python API
-            runner: ubuntu-latest
-            arch: i686
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/python_api
-          - test-category: Python API
-            runner: ubuntu-24.04-arm
-            arch: aarch64
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/python_api
-
-          - test-category: functionalities
-            runner: ubuntu-latest
-            arch: x86_64
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/functionalities
-          - test-category: functionalities
-            runner: ubuntu-latest
-            arch: i686
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/functionalities
-          - test-category: functionalities
-            runner: ubuntu-24.04-arm
-            arch: aarch64
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/functionalities
-
-    steps:
-      - if: matrix.arch == 'i686'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -qq --no-install-recommends gcc-multilib g++-multilib
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: llvm-${{ runner.os }}-${{ runner.arch }}
-          path: ${{ github.workspace }}/BinaryCache
-      - name: untar llvm artifacts
-        run: |
-          tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/llvm.tar
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: linux-${{ matrix.arch }}-ds2
-          path: ${{ github.workspace }}/BinaryCache
-      - name: untar ds2 artifacts
-        run: |
-          tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/ds2.tar
-
-      - name: Checkout llvm project
-        uses: actions/checkout@v7
-        with:
-          repository: llvm/llvm-project
-          ref: ${{ env.LLVM_REF }}
-          path: ${{ github.workspace }}/SourceCache/llvm
-
-      - name: Checkout ds2
-        uses: actions/checkout@v7
-        with:
-          path: ${{ github.workspace }}/SourceCache/ds2
-
-      - run: |
-          mkdir -p ${{ github.workspace }}/temp
-          ${{ github.workspace }}/BinaryCache/ds2/ds2 platform --server --daemonize --listen localhost:5432
-          ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest 1>/dev/null  \
-              --out-of-tree-debugserver                                         \
-              --arch ${{ matrix.arch }}                                         \
-              --platform-name remote-linux                                      \
-              --platform-url connect://localhost:5432                           \
-              --platform-working-dir ${{ github.workspace }}/temp               \
-              --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/linux-${{ matrix.arch }}.excluded \
-              --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/ds2/linux-${{ matrix.arch }}.excluded \
-              --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/non-debugserver-tests.excluded \
-              -v \
-              ${{ matrix.test-subdirs }}
-
-  test-android-x86:
-    needs: [android-windows-ndk, build-lldb-linux]
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - test-category: misc
-            arch: x86_64
-            llvm-arch: x86_64
-            android-api-level: 28
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/android
-              SourceCache/llvm/lldb/test/API/api
-              SourceCache/llvm/lldb/test/API/lang
-              SourceCache/llvm/lldb/test/API/linux
-              SourceCache/llvm/lldb/test/API/tools
-              SourceCache/llvm/lldb/test/API/sanity
-              SourceCache/llvm/lldb/test/API/types
-
-          - test-category: commands
-            arch: x86_64
-            llvm-arch: x86_64
-            android-api-level: 28
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/commands
-
-          - test-category: Python API
-            arch: x86_64
-            llvm-arch: x86_64
-            android-api-level: 28
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/python_api
-
-          - test-category: functionalities
-            arch: x86_64
-            llvm-arch: x86_64
-            android-api-level: 28
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/functionalities
-
-          # Run a small sub-set of tests on arm64. The emulator is very slow
-          # so it is not practical to run more tests until we can run on an
-          # arm64 runner with virtualization.
-          - test-category: sanity
-            arch: arm64-v8a
-            llvm-arch: aarch64
-            # Android emulator supports ARM on x86 only on API < 28
-            android-api-level: 27
-            # This is the most recent build of the emulator that supports
-            # booting arm64 images.
-            emulator-build: 12234392
-            emulator-options: -qemu -machine virt -cpu max
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/android
-              SourceCache/llvm/lldb/test/API/api
-              SourceCache/llvm/lldb/test/API/linux
-              SourceCache/llvm/lldb/test/API/sanity
-
-    name: Test Android ${{ matrix.arch}} ${{ matrix.test-category }}
-
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: llvm-${{ runner.os }}-${{ runner.arch }}
-          path: ${{ github.workspace }}/BinaryCache
-      - name: untar llvm artifacts
-        run: |
-          tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/llvm.tar
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: android-${{ matrix.arch }}-ds2
-          path: ${{ github.workspace }}/BinaryCache
-      - name: untar ds2 artifacts
-        run: |
-          tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/ds2.tar
-
-      - name: Checkout llvm project
-        uses: actions/checkout@v7
-        with:
-          repository: llvm/llvm-project
-          ref: ${{ env.LLVM_REF }}
-          path: ${{ github.workspace }}/SourceCache/llvm
-
-      - name: Checkout ds2
-        uses: actions/checkout@v7
-        with:
-          path: ${{ github.workspace }}/SourceCache/ds2
-
-      # Cache the contents of $HOME/.android which contains emulators,
-      # snapshots, and adb state.
-      - name: Setup AVD cache
-        uses: actions/cache@v6
-        id: avd-cache
-        with:
-          path: ~/.android/**
-          key: avd-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.android-api-level }}
-
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          emulator-build: ${{ matrix.emulator-build }}
-          api-level: ${{ matrix.android-api-level }}
-          arch: ${{ matrix.arch }}
-          force-avd-creation: false
-          emulator-options: -no-window -noaudio -no-boot-anim -camera-back none -gpu swiftshader_indirect ${{ matrix.emulator-options }}
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-
-      - name: Run lldb tests against ds2 on Android emulator
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          emulator-build: ${{ matrix.emulator-build }}
-          api-level: ${{ matrix.android-api-level }}
-          arch: ${{ matrix.arch }}
-          force-avd-creation: false
-          # NOTE: -no-snapshot will not load or save state and the emulator will
-          # cold boot. Ideally, we would specify -no-snapshot-save instead so it
-          # would load the snapshot created in the caching step (but not save a
-          # new one). However, doing that causes the emulator to hang during
-          # shutdown. We're still saving time by reusing the device created in
-          # the caching step and not wiping userdata on boot.
-          emulator-options: -no-snapshot -no-window -noaudio -no-boot-anim -camera-back none -gpu swiftshader_indirect ${{ matrix.emulator-options }}
-          disable-animations: true
-          script: >
-            $ANDROID_SDK_ROOT/platform-tools/adb forward tcp:5432 tcp:5432
-
-            $ANDROID_SDK_ROOT/platform-tools/adb push "${{ github.workspace }}/BinaryCache/ds2/ds2" /data/local/tmp
-
-            $ANDROID_SDK_ROOT/platform-tools/adb shell "chmod +x /data/local/tmp/ds2"
-
-            $ANDROID_SDK_ROOT/platform-tools/adb shell "/data/local/tmp/ds2 platform --server --daemonize --listen localhost:5432"
-
-            ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest 1>/dev/null
-            --out-of-tree-debugserver
-            --arch ${{ matrix.llvm-arch }}
-            --platform-name remote-android
-            --platform-url connect://localhost:5432
-            --platform-working-dir /data/local/tmp
-            --compiler=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/${{ matrix.llvm-arch }}-linux-android${{ matrix.android-api-level }}-clang
-            --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/ds2/android-${{ matrix.llvm-arch }}.excluded
-            --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/android-${{ matrix.llvm-arch }}.excluded
-            --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/non-debugserver-tests.excluded
-            -v
-            ${{ matrix.test-subdirs }}
+  test-android:
+    needs: [vars, android-windows-ndk, build-lldb-linux]
+    uses: ./.github/workflows/test.yml
+    with:
+      llvm-ref: ${{ needs.vars.outputs.llvm-ref }}
+      platform: android

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,477 @@
+name: Test
+
+on:
+  workflow_call:
+    inputs:
+      llvm-ref:
+        description: llvm-project commit/ref the build artifacts were built against
+        required: true
+        type: string
+      platform:
+        description: >-
+          Which platform's jobs to run in this call (linux|android). Callers
+          invoke this workflow once per platform, gated on just that
+          platform's own build jobs, so e.g. Android tests can start as soon
+          as the Android build finishes without waiting on the Linux build.
+          Adding Windows support later is meant to follow the same shape:
+          a new test-windows-* job gated on `inputs.platform == 'windows'`,
+          plus a third call from build.yml -- nothing about the Linux/Android
+          jobs below should need to change.
+        required: true
+        type: string
+
+jobs:
+
+  # ---------------------------------------------------------------------
+  # Linux
+  # ---------------------------------------------------------------------
+  #
+  # Each category shard is a genuinely separate job/runner (a strategy.matrix,
+  # same as before this file existed) rather than a single job backgrounding
+  # all four shards together: that would put four ds2+lldb-dotest instances
+  # on one runner's fixed CPU budget, contending with each other instead of
+  # actually running in parallel. The job's own `name:` deliberately does NOT
+  # interpolate matrix.test-category (unlike the version of this file that a
+  # reviewer flagged): GitHub groups matrix jobs that share an identical name
+  # into a single collapsible entry in the PR checks list, which is what
+  # actually fixes the one-check-per-category-per-arch clutter -- varying the
+  # name per category is what defeats that grouping and is why each category
+  # showed up as its own separate, differently-named check before. The
+  # *-status job per arch gives branch protection one plain, matrix-independent
+  # check name to require rather than depending on how that grouping is
+  # surfaced there.
+
+  test-linux-i686:
+    if: inputs.platform == 'linux'
+    runs-on: ubuntu-latest
+    name: Test Linux i686
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test-category: misc
+            test-subdirs: >-
+              SourceCache/llvm/lldb/test/API/api
+              SourceCache/llvm/lldb/test/API/lang
+              SourceCache/llvm/lldb/test/API/linux
+              SourceCache/llvm/lldb/test/API/tools
+              SourceCache/llvm/lldb/test/API/sanity
+              SourceCache/llvm/lldb/test/API/types
+          - test-category: commands
+            test-subdirs: SourceCache/llvm/lldb/test/API/commands
+          - test-category: Python API
+            test-subdirs: SourceCache/llvm/lldb/test/API/python_api
+          - test-category: functionalities
+            test-subdirs: SourceCache/llvm/lldb/test/API/functionalities
+
+    steps:
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -qq --no-install-recommends gcc-multilib g++-multilib
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: llvm-Linux-X64
+          path: ${{ github.workspace }}/BinaryCache
+      - run: tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/llvm.tar
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: linux-i686-ds2
+          path: ${{ github.workspace }}/BinaryCache
+      - run: tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/ds2.tar
+
+      - name: Checkout llvm project
+        uses: actions/checkout@v7
+        with:
+          repository: llvm/llvm-project
+          ref: ${{ inputs.llvm-ref }}
+          path: ${{ github.workspace }}/SourceCache/llvm
+
+      - name: Checkout ds2
+        uses: actions/checkout@v7
+        with:
+          path: ${{ github.workspace }}/SourceCache/ds2
+
+      - uses: ./SourceCache/ds2/.github/actions/run-lldb-tests
+        with:
+          ds2-path: ${{ github.workspace }}/BinaryCache/ds2/ds2
+          lldb-dotest-path: ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest
+          ds2-repo-path: ${{ github.workspace }}/SourceCache/ds2
+          arch: i686
+          platform: linux
+          working-dir: ${{ github.workspace }}/temp
+          test-subdirs: ${{ matrix.test-subdirs }}
+
+  test-linux-i686-status:
+    needs: [test-linux-i686]
+    if: always() && inputs.platform == 'linux'
+    runs-on: ubuntu-latest
+    name: Test Linux i686 (status)
+    steps:
+      - if: needs.test-linux-i686.result != 'success'
+        run: exit 1
+
+  test-linux-x86_64:
+    if: inputs.platform == 'linux'
+    runs-on: ubuntu-latest
+    name: Test Linux x86_64
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test-category: misc
+            test-subdirs: >-
+              SourceCache/llvm/lldb/test/API/api
+              SourceCache/llvm/lldb/test/API/lang
+              SourceCache/llvm/lldb/test/API/linux
+              SourceCache/llvm/lldb/test/API/tools
+              SourceCache/llvm/lldb/test/API/sanity
+              SourceCache/llvm/lldb/test/API/types
+          - test-category: commands
+            test-subdirs: SourceCache/llvm/lldb/test/API/commands
+          - test-category: Python API
+            test-subdirs: SourceCache/llvm/lldb/test/API/python_api
+          - test-category: functionalities
+            test-subdirs: SourceCache/llvm/lldb/test/API/functionalities
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: llvm-Linux-X64
+          path: ${{ github.workspace }}/BinaryCache
+      - run: tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/llvm.tar
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: linux-x86_64-ds2
+          path: ${{ github.workspace }}/BinaryCache
+      - run: tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/ds2.tar
+
+      - name: Checkout llvm project
+        uses: actions/checkout@v7
+        with:
+          repository: llvm/llvm-project
+          ref: ${{ inputs.llvm-ref }}
+          path: ${{ github.workspace }}/SourceCache/llvm
+
+      - name: Checkout ds2
+        uses: actions/checkout@v7
+        with:
+          path: ${{ github.workspace }}/SourceCache/ds2
+
+      - uses: ./SourceCache/ds2/.github/actions/run-lldb-tests
+        with:
+          ds2-path: ${{ github.workspace }}/BinaryCache/ds2/ds2
+          lldb-dotest-path: ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest
+          ds2-repo-path: ${{ github.workspace }}/SourceCache/ds2
+          arch: x86_64
+          platform: linux
+          working-dir: ${{ github.workspace }}/temp
+          test-subdirs: ${{ matrix.test-subdirs }}
+
+  test-linux-x86_64-status:
+    needs: [test-linux-x86_64]
+    if: always() && inputs.platform == 'linux'
+    runs-on: ubuntu-latest
+    name: Test Linux x86_64 (status)
+    steps:
+      - if: needs.test-linux-x86_64.result != 'success'
+        run: exit 1
+
+  test-linux-aarch64:
+    if: inputs.platform == 'linux'
+    runs-on: ubuntu-24.04-arm
+    name: Test Linux aarch64
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test-category: misc
+            test-subdirs: >-
+              SourceCache/llvm/lldb/test/API/api
+              SourceCache/llvm/lldb/test/API/lang
+              SourceCache/llvm/lldb/test/API/linux
+              SourceCache/llvm/lldb/test/API/tools
+              SourceCache/llvm/lldb/test/API/sanity
+              SourceCache/llvm/lldb/test/API/types
+          - test-category: commands
+            test-subdirs: SourceCache/llvm/lldb/test/API/commands
+          - test-category: Python API
+            test-subdirs: SourceCache/llvm/lldb/test/API/python_api
+          - test-category: functionalities
+            test-subdirs: SourceCache/llvm/lldb/test/API/functionalities
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: llvm-Linux-ARM64
+          path: ${{ github.workspace }}/BinaryCache
+      - run: tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/llvm.tar
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: linux-aarch64-ds2
+          path: ${{ github.workspace }}/BinaryCache
+      - run: tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/ds2.tar
+
+      - name: Checkout llvm project
+        uses: actions/checkout@v7
+        with:
+          repository: llvm/llvm-project
+          ref: ${{ inputs.llvm-ref }}
+          path: ${{ github.workspace }}/SourceCache/llvm
+
+      - name: Checkout ds2
+        uses: actions/checkout@v7
+        with:
+          path: ${{ github.workspace }}/SourceCache/ds2
+
+      - uses: ./SourceCache/ds2/.github/actions/run-lldb-tests
+        with:
+          ds2-path: ${{ github.workspace }}/BinaryCache/ds2/ds2
+          lldb-dotest-path: ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest
+          ds2-repo-path: ${{ github.workspace }}/SourceCache/ds2
+          arch: aarch64
+          platform: linux
+          working-dir: ${{ github.workspace }}/temp
+          test-subdirs: ${{ matrix.test-subdirs }}
+
+  test-linux-aarch64-status:
+    needs: [test-linux-aarch64]
+    if: always() && inputs.platform == 'linux'
+    runs-on: ubuntu-latest
+    name: Test Linux aarch64 (status)
+    steps:
+      - if: needs.test-linux-aarch64.result != 'success'
+        run: exit 1
+
+  # ---------------------------------------------------------------------
+  # Android
+  # ---------------------------------------------------------------------
+  #
+  # The emulator-runner action takes the whole test invocation as a single
+  # shell script string executed inside its own wrapper, so it can't invoke
+  # the run-lldb-tests composite action as a normal step the way the Linux
+  # jobs do -- the dotest invocation stays inlined here, same as before this
+  # file existed.
+
+  test-android-x86_64:
+    if: inputs.platform == 'android'
+    runs-on: ubuntu-latest
+    name: Test Android x86_64
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test-category: misc
+            test-subdirs: >-
+              SourceCache/llvm/lldb/test/API/android
+              SourceCache/llvm/lldb/test/API/api
+              SourceCache/llvm/lldb/test/API/lang
+              SourceCache/llvm/lldb/test/API/linux
+              SourceCache/llvm/lldb/test/API/tools
+              SourceCache/llvm/lldb/test/API/sanity
+              SourceCache/llvm/lldb/test/API/types
+          - test-category: commands
+            test-subdirs: SourceCache/llvm/lldb/test/API/commands
+          - test-category: Python API
+            test-subdirs: SourceCache/llvm/lldb/test/API/python_api
+          - test-category: functionalities
+            test-subdirs: SourceCache/llvm/lldb/test/API/functionalities
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: llvm-Linux-X64
+          path: ${{ github.workspace }}/BinaryCache
+      - run: tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/llvm.tar
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: android-x86_64-ds2
+          path: ${{ github.workspace }}/BinaryCache
+      - run: tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/ds2.tar
+
+      - name: Checkout llvm project
+        uses: actions/checkout@v7
+        with:
+          repository: llvm/llvm-project
+          ref: ${{ inputs.llvm-ref }}
+          path: ${{ github.workspace }}/SourceCache/llvm
+
+      - name: Checkout ds2
+        uses: actions/checkout@v7
+        with:
+          path: ${{ github.workspace }}/SourceCache/ds2
+
+      # Cache the contents of $HOME/.android which contains emulators,
+      # snapshots, and adb state.
+      - name: Setup AVD cache
+        uses: actions/cache@v6
+        id: avd-cache
+        with:
+          path: ~/.android/**
+          key: avd-${{ runner.os }}-x86_64-28
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 28
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -noaudio -no-boot-anim -camera-back none -gpu swiftshader_indirect
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run lldb tests against ds2 on Android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 28
+          arch: x86_64
+          force-avd-creation: false
+          # NOTE: -no-snapshot will not load or save state and the emulator will
+          # cold boot. Ideally, we would specify -no-snapshot-save instead so it
+          # would load the snapshot created in the caching step (but not save a
+          # new one). However, doing that causes the emulator to hang during
+          # shutdown. We're still saving time by reusing the device created in
+          # the caching step and not wiping userdata on boot.
+          emulator-options: -no-snapshot -no-window -noaudio -no-boot-anim -camera-back none -gpu swiftshader_indirect
+          disable-animations: true
+          script: >
+            $ANDROID_SDK_ROOT/platform-tools/adb forward tcp:5432 tcp:5432
+
+            $ANDROID_SDK_ROOT/platform-tools/adb push "${{ github.workspace }}/BinaryCache/ds2/ds2" /data/local/tmp
+
+            $ANDROID_SDK_ROOT/platform-tools/adb shell "chmod +x /data/local/tmp/ds2"
+
+            $ANDROID_SDK_ROOT/platform-tools/adb shell "/data/local/tmp/ds2 platform --server --daemonize --listen localhost:5432"
+
+            ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest 1>/dev/null
+            --out-of-tree-debugserver
+            --arch x86_64
+            --platform-name remote-android
+            --platform-url connect://localhost:5432
+            --platform-working-dir /data/local/tmp
+            --compiler=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android28-clang
+            --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/ds2/android-x86_64.excluded
+            --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/android-x86_64.excluded
+            --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/non-debugserver-tests.excluded
+            -v
+            ${{ matrix.test-subdirs }}
+
+  test-android-x86_64-status:
+    needs: [test-android-x86_64]
+    if: always() && inputs.platform == 'android'
+    runs-on: ubuntu-latest
+    name: Test Android x86_64 (status)
+    steps:
+      - if: needs.test-android-x86_64.result != 'success'
+        run: exit 1
+
+  # Run a small sub-set of tests on arm64. The emulator is very slow so it is
+  # not practical to run more tests until we can run on an arm64 runner with
+  # virtualization. Only one category runs here, so this already reports as
+  # a single check with no matrix/grouping concerns.
+  test-android-arm64-v8a:
+    if: inputs.platform == 'android'
+    runs-on: ubuntu-latest
+    name: Test Android arm64-v8a sanity
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: llvm-Linux-X64
+          path: ${{ github.workspace }}/BinaryCache
+      - run: tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/llvm.tar
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: android-arm64-v8a-ds2
+          path: ${{ github.workspace }}/BinaryCache
+      - run: tar -C ${{ github.workspace }}/BinaryCache -xvf ${{ github.workspace }}/BinaryCache/ds2.tar
+
+      - name: Checkout llvm project
+        uses: actions/checkout@v7
+        with:
+          repository: llvm/llvm-project
+          ref: ${{ inputs.llvm-ref }}
+          path: ${{ github.workspace }}/SourceCache/llvm
+
+      - name: Checkout ds2
+        uses: actions/checkout@v7
+        with:
+          path: ${{ github.workspace }}/SourceCache/ds2
+
+      - name: Setup AVD cache
+        uses: actions/cache@v6
+        id: avd-cache
+        with:
+          path: ~/.android/**
+          key: avd-${{ runner.os }}-arm64-v8a-27
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          # Android emulator supports ARM on x86 only on API < 28.
+          api-level: 27
+          arch: arm64-v8a
+          force-avd-creation: false
+          # This is the most recent build of the emulator that supports
+          # booting arm64 images.
+          emulator-build: 12234392
+          emulator-options: -no-window -noaudio -no-boot-anim -camera-back none -gpu swiftshader_indirect -qemu -machine virt -cpu max
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run lldb tests against ds2 on Android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 27
+          arch: arm64-v8a
+          force-avd-creation: false
+          emulator-build: 12234392
+          emulator-options: -no-snapshot -no-window -noaudio -no-boot-anim -camera-back none -gpu swiftshader_indirect -qemu -machine virt -cpu max
+          disable-animations: true
+          script: >
+            $ANDROID_SDK_ROOT/platform-tools/adb forward tcp:5432 tcp:5432
+
+            $ANDROID_SDK_ROOT/platform-tools/adb push "${{ github.workspace }}/BinaryCache/ds2/ds2" /data/local/tmp
+
+            $ANDROID_SDK_ROOT/platform-tools/adb shell "chmod +x /data/local/tmp/ds2"
+
+            $ANDROID_SDK_ROOT/platform-tools/adb shell "/data/local/tmp/ds2 platform --server --daemonize --listen localhost:5432"
+
+            ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest 1>/dev/null
+            --out-of-tree-debugserver
+            --arch aarch64
+            --platform-name remote-android
+            --platform-url connect://localhost:5432
+            --platform-working-dir /data/local/tmp
+            --compiler=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android27-clang
+            --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/ds2/android-aarch64.excluded
+            --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/android-aarch64.excluded
+            --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/non-debugserver-tests.excluded
+            -v
+            SourceCache/llvm/lldb/test/API/android
+            SourceCache/llvm/lldb/test/API/api
+            SourceCache/llvm/lldb/test/API/linux
+            SourceCache/llvm/lldb/test/API/sanity

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,29 +46,40 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Linux i686
 
+    # test-category is the matrix's only key -- GitHub renders every matrix
+    # key/value pair in the check name (e.g. "Test Linux i686 (Python API)"),
+    # so test-subdirs is resolved from test-category by the step below
+    # instead of being a second matrix axis, which would otherwise render as
+    # "Test Linux i686 (Python API, SourceCache/llvm/lldb/test/API/python_api)".
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - test-category: misc
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/api
-              SourceCache/llvm/lldb/test/API/lang
-              SourceCache/llvm/lldb/test/API/linux
-              SourceCache/llvm/lldb/test/API/tools
-              SourceCache/llvm/lldb/test/API/sanity
-              SourceCache/llvm/lldb/test/API/types
-          - test-category: commands
-            test-subdirs: SourceCache/llvm/lldb/test/API/commands
-          - test-category: Python API
-            test-subdirs: SourceCache/llvm/lldb/test/API/python_api
-          - test-category: functionalities
-            test-subdirs: SourceCache/llvm/lldb/test/API/functionalities
+        test-category: [misc, commands, Python API, functionalities]
 
     steps:
       - run: |
           sudo apt-get update
           sudo apt-get install -qq --no-install-recommends gcc-multilib g++-multilib
+
+      - name: Resolve test subdirectories
+        id: test-subdirs
+        shell: bash
+        run: |
+          case "${{ matrix.test-category }}" in
+            misc)
+              dirs="SourceCache/llvm/lldb/test/API/api SourceCache/llvm/lldb/test/API/lang SourceCache/llvm/lldb/test/API/linux SourceCache/llvm/lldb/test/API/tools SourceCache/llvm/lldb/test/API/sanity SourceCache/llvm/lldb/test/API/types"
+              ;;
+            commands)
+              dirs="SourceCache/llvm/lldb/test/API/commands"
+              ;;
+            "Python API")
+              dirs="SourceCache/llvm/lldb/test/API/python_api"
+              ;;
+            functionalities)
+              dirs="SourceCache/llvm/lldb/test/API/functionalities"
+              ;;
+          esac
+          echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v8
         with:
@@ -102,7 +113,7 @@ jobs:
           arch: i686
           platform: linux
           working-dir: ${{ github.workspace }}/temp
-          test-subdirs: ${{ matrix.test-subdirs }}
+          test-subdirs: ${{ steps.test-subdirs.outputs.dirs }}
 
   test-linux-i686-status:
     needs: [test-linux-i686]
@@ -121,23 +132,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - test-category: misc
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/api
-              SourceCache/llvm/lldb/test/API/lang
-              SourceCache/llvm/lldb/test/API/linux
-              SourceCache/llvm/lldb/test/API/tools
-              SourceCache/llvm/lldb/test/API/sanity
-              SourceCache/llvm/lldb/test/API/types
-          - test-category: commands
-            test-subdirs: SourceCache/llvm/lldb/test/API/commands
-          - test-category: Python API
-            test-subdirs: SourceCache/llvm/lldb/test/API/python_api
-          - test-category: functionalities
-            test-subdirs: SourceCache/llvm/lldb/test/API/functionalities
+        test-category: [misc, commands, Python API, functionalities]
 
     steps:
+      - name: Resolve test subdirectories
+        id: test-subdirs
+        shell: bash
+        run: |
+          case "${{ matrix.test-category }}" in
+            misc)
+              dirs="SourceCache/llvm/lldb/test/API/api SourceCache/llvm/lldb/test/API/lang SourceCache/llvm/lldb/test/API/linux SourceCache/llvm/lldb/test/API/tools SourceCache/llvm/lldb/test/API/sanity SourceCache/llvm/lldb/test/API/types"
+              ;;
+            commands)
+              dirs="SourceCache/llvm/lldb/test/API/commands"
+              ;;
+            "Python API")
+              dirs="SourceCache/llvm/lldb/test/API/python_api"
+              ;;
+            functionalities)
+              dirs="SourceCache/llvm/lldb/test/API/functionalities"
+              ;;
+          esac
+          echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
+
       - uses: actions/download-artifact@v8
         with:
           name: llvm-Linux-X64
@@ -170,7 +187,7 @@ jobs:
           arch: x86_64
           platform: linux
           working-dir: ${{ github.workspace }}/temp
-          test-subdirs: ${{ matrix.test-subdirs }}
+          test-subdirs: ${{ steps.test-subdirs.outputs.dirs }}
 
   test-linux-x86_64-status:
     needs: [test-linux-x86_64]
@@ -189,23 +206,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - test-category: misc
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/api
-              SourceCache/llvm/lldb/test/API/lang
-              SourceCache/llvm/lldb/test/API/linux
-              SourceCache/llvm/lldb/test/API/tools
-              SourceCache/llvm/lldb/test/API/sanity
-              SourceCache/llvm/lldb/test/API/types
-          - test-category: commands
-            test-subdirs: SourceCache/llvm/lldb/test/API/commands
-          - test-category: Python API
-            test-subdirs: SourceCache/llvm/lldb/test/API/python_api
-          - test-category: functionalities
-            test-subdirs: SourceCache/llvm/lldb/test/API/functionalities
+        test-category: [misc, commands, Python API, functionalities]
 
     steps:
+      - name: Resolve test subdirectories
+        id: test-subdirs
+        shell: bash
+        run: |
+          case "${{ matrix.test-category }}" in
+            misc)
+              dirs="SourceCache/llvm/lldb/test/API/api SourceCache/llvm/lldb/test/API/lang SourceCache/llvm/lldb/test/API/linux SourceCache/llvm/lldb/test/API/tools SourceCache/llvm/lldb/test/API/sanity SourceCache/llvm/lldb/test/API/types"
+              ;;
+            commands)
+              dirs="SourceCache/llvm/lldb/test/API/commands"
+              ;;
+            "Python API")
+              dirs="SourceCache/llvm/lldb/test/API/python_api"
+              ;;
+            functionalities)
+              dirs="SourceCache/llvm/lldb/test/API/functionalities"
+              ;;
+          esac
+          echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
+
       - uses: actions/download-artifact@v8
         with:
           name: llvm-Linux-ARM64
@@ -238,7 +261,7 @@ jobs:
           arch: aarch64
           platform: linux
           working-dir: ${{ github.workspace }}/temp
-          test-subdirs: ${{ matrix.test-subdirs }}
+          test-subdirs: ${{ steps.test-subdirs.outputs.dirs }}
 
   test-linux-aarch64-status:
     needs: [test-linux-aarch64]
@@ -267,24 +290,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - test-category: misc
-            test-subdirs: >-
-              SourceCache/llvm/lldb/test/API/android
-              SourceCache/llvm/lldb/test/API/api
-              SourceCache/llvm/lldb/test/API/lang
-              SourceCache/llvm/lldb/test/API/linux
-              SourceCache/llvm/lldb/test/API/tools
-              SourceCache/llvm/lldb/test/API/sanity
-              SourceCache/llvm/lldb/test/API/types
-          - test-category: commands
-            test-subdirs: SourceCache/llvm/lldb/test/API/commands
-          - test-category: Python API
-            test-subdirs: SourceCache/llvm/lldb/test/API/python_api
-          - test-category: functionalities
-            test-subdirs: SourceCache/llvm/lldb/test/API/functionalities
+        test-category: [misc, commands, Python API, functionalities]
 
     steps:
+      - name: Resolve test subdirectories
+        id: test-subdirs
+        shell: bash
+        run: |
+          case "${{ matrix.test-category }}" in
+            misc)
+              dirs="SourceCache/llvm/lldb/test/API/android SourceCache/llvm/lldb/test/API/api SourceCache/llvm/lldb/test/API/lang SourceCache/llvm/lldb/test/API/linux SourceCache/llvm/lldb/test/API/tools SourceCache/llvm/lldb/test/API/sanity SourceCache/llvm/lldb/test/API/types"
+              ;;
+            commands)
+              dirs="SourceCache/llvm/lldb/test/API/commands"
+              ;;
+            "Python API")
+              dirs="SourceCache/llvm/lldb/test/API/python_api"
+              ;;
+            functionalities)
+              dirs="SourceCache/llvm/lldb/test/API/functionalities"
+              ;;
+          esac
+          echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
+
       - uses: actions/download-artifact@v8
         with:
           name: llvm-Linux-X64
@@ -358,7 +386,7 @@ jobs:
 
             $ANDROID_SDK_ROOT/platform-tools/adb shell "/data/local/tmp/ds2 platform --server --daemonize --listen localhost:5432"
 
-            ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest 1>/dev/null
+            ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest
             --out-of-tree-debugserver
             --arch x86_64
             --platform-name remote-android
@@ -369,7 +397,9 @@ jobs:
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/android-x86_64.excluded
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/non-debugserver-tests.excluded
             -v
-            ${{ matrix.test-subdirs }}
+            ${{ steps.test-subdirs.outputs.dirs }}
+            1>/dev/null 2>/tmp/dotest-android-x86_64.log;
+            rc=$?; grep -v '^UNSUPPORTED: LLDB ' /tmp/dotest-android-x86_64.log; exit $rc
 
   test-android-x86_64-status:
     needs: [test-android-x86_64]
@@ -460,7 +490,7 @@ jobs:
 
             $ANDROID_SDK_ROOT/platform-tools/adb shell "/data/local/tmp/ds2 platform --server --daemonize --listen localhost:5432"
 
-            ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest 1>/dev/null
+            ${{ github.workspace }}/BinaryCache/llvm/bin/lldb-dotest
             --out-of-tree-debugserver
             --arch aarch64
             --platform-name remote-android
@@ -475,3 +505,5 @@ jobs:
             SourceCache/llvm/lldb/test/API/api
             SourceCache/llvm/lldb/test/API/linux
             SourceCache/llvm/lldb/test/API/sanity
+            1>/dev/null 2>/tmp/dotest-android-arm64-v8a.log;
+            rc=$?; grep -v '^UNSUPPORTED: LLDB ' /tmp/dotest-android-arm64-v8a.log; exit $rc


### PR DESCRIPTION
build.yml's test jobs each ran every test-category as one job with an internal matrix, so every category showed up as its own separate check on the PR (e.g. "Test Linux x86_64 misc", "...commands", "...Python API", "...functionalities" -- four checks per arch, times three Linux arches and two Android arches).

Move all test jobs into a new test.yml, invoked from build.yml via workflow_call once per platform, each call gated on only that platform's own build jobs (`needs: [linux, build-lldb-linux]` for Linux, `needs: [android-windows-ndk, build-lldb-linux]` for Android) rather than on every build job finishing -- so e.g. Android tests start as soon as the Android build and the shared lldb-dotest build are ready, independent of how long the Linux/Windows/macOS/FreeBSD builds take. test.yml takes a `platform` input and gates each of its jobs on it, so the same file serves multiple independent calls instead of needing one file per platform; Windows testing can follow the same shape later (new test-windows-* jobs gated on `platform == 'windows'`, a third call from build.yml) without touching what's here.

Split each arch's four category shards into their own job (still parallel) followed by a tiny gate job that checks `needs.<job>.result`, so the PR shows one consolidated check per arch (e.g. "Test Linux x86_64") instead of four. The category shards still exist and still run independently underneath; only the reported status is rolled up.

Also pull the ds2-platform-server-plus-lldb-dotest invocation, so far duplicated across every Linux category shard, into a composite action (.github/actions/run-lldb-tests) parameterized on what actually varies (arch, platform name, working directory, test subdirs). Android's emulator-runner wrapping takes the whole test invocation as a single shell script string rather than a normal step sequence, so it can't call the composite action the same way and stays inlined.