### PR TITLE
Adjust code structure for size improvements

### DIFF
--- a/Headers/DebugServer2/Architecture/X86/CPUState.h
+++ b/Headers/DebugServer2/Architecture/X86/CPUState.h
@@ -192,47 +192,27 @@ public:
 
 public:
   inline void getStopGPState(GPRegisterStopMap &regs, bool forLLDB) const {
-    if (forLLDB) {
-#define _SETREG(REG) regs[reg_lldb_##REG] = _REGVALUE(REG)
-      _SETREG(eax);
-      _SETREG(ebx);
-      _SETREG(ecx);
-      _SETREG(edx);
-      _SETREG(ebx);
-      _SETREG(esi);
-      _SETREG(edi);
-      _SETREG(ebp);
-      _SETREG(esp);
-      _SETREG(eip);
-      _SETREG(cs);
-      _SETREG(ss);
-      _SETREG(ds);
-      _SETREG(es);
-      _SETREG(fs);
-      _SETREG(gs);
-      _SETREG(eflags);
-#undef _SETREG
-    } else {
-#define _SETREG(REG) regs[reg_gdb_##REG] = _REGVALUE(REG)
-      _SETREG(eax);
-      _SETREG(ebx);
-      _SETREG(ecx);
-      _SETREG(edx);
-      _SETREG(ebx);
-      _SETREG(esi);
-      _SETREG(edi);
-      _SETREG(ebp);
-      _SETREG(esp);
-      _SETREG(eip);
-      _SETREG(cs);
-      _SETREG(ss);
-      _SETREG(ds);
-      _SETREG(es);
-      _SETREG(fs);
-      _SETREG(gs);
-      _SETREG(eflags);
-#undef _SETREG
-    }
+    auto set = [&](uint32_t lldbReg, uint32_t gdbReg,
+                   const GPRegisterValue &value) {
+      regs[forLLDB ? lldbReg : gdbReg] = value;
+    };
+
+    set(reg_lldb_eax, reg_gdb_eax, _REGVALUE(eax));
+    set(reg_lldb_ebx, reg_gdb_ebx, _REGVALUE(ebx));
+    set(reg_lldb_ecx, reg_gdb_ecx, _REGVALUE(ecx));
+    set(reg_lldb_edx, reg_gdb_edx, _REGVALUE(edx));
+    set(reg_lldb_esi, reg_gdb_esi, _REGVALUE(esi));
+    set(reg_lldb_edi, reg_gdb_edi, _REGVALUE(edi));
+    set(reg_lldb_ebp, reg_gdb_ebp, _REGVALUE(ebp));
+    set(reg_lldb_esp, reg_gdb_esp, _REGVALUE(esp));
+    set(reg_lldb_eip, reg_gdb_eip, _REGVALUE(eip));
+    set(reg_lldb_cs, reg_gdb_cs, _REGVALUE(cs));
+    set(reg_lldb_ss, reg_gdb_ss, _REGVALUE(ss));
+    set(reg_lldb_ds, reg_gdb_ds, _REGVALUE(ds));
+    set(reg_lldb_es, reg_gdb_es, _REGVALUE(es));
+    set(reg_lldb_fs, reg_gdb_fs, _REGVALUE(fs));
+    set(reg_lldb_gs, reg_gdb_gs, _REGVALUE(gs));
+    set(reg_lldb_eflags, reg_gdb_eflags, _REGVALUE(eflags));
   }
 #undef _REGVALUE
 

--- a/Headers/DebugServer2/Architecture/X86_64/CPUState.h
+++ b/Headers/DebugServer2/Architecture/X86_64/CPUState.h
@@ -249,61 +249,35 @@ public:
 
 public:
   inline void getStopGPState(GPRegisterStopMap &regs, bool forLLDB) const {
-    if (forLLDB) {
-#define _SETREG(REG) regs[reg_lldb_##REG] = _REGVALUE(REG)
-      _SETREG(rax);
-      _SETREG(rcx);
-      _SETREG(rdx);
-      _SETREG(rbx);
-      _SETREG(rsi);
-      _SETREG(rdi);
-      _SETREG(rsp);
-      _SETREG(rbp);
-      _SETREG(r8);
-      _SETREG(r9);
-      _SETREG(r10);
-      _SETREG(r11);
-      _SETREG(r12);
-      _SETREG(r13);
-      _SETREG(r14);
-      _SETREG(r15);
-      _SETREG(rip);
-      _SETREG(eflags);
-      _SETREG(cs);
-      _SETREG(ss);
-      _SETREG(ds);
-      _SETREG(es);
-      _SETREG(fs);
-      _SETREG(gs);
-#undef _SETREG
-    } else {
-#define _SETREG(REG) regs[reg_gdb_##REG] = _REGVALUE(REG)
-      _SETREG(rax);
-      _SETREG(rcx);
-      _SETREG(rdx);
-      _SETREG(rbx);
-      _SETREG(rsi);
-      _SETREG(rdi);
-      _SETREG(rsp);
-      _SETREG(rbp);
-      _SETREG(r8);
-      _SETREG(r9);
-      _SETREG(r10);
-      _SETREG(r11);
-      _SETREG(r12);
-      _SETREG(r13);
-      _SETREG(r14);
-      _SETREG(r15);
-      _SETREG(rip);
-      _SETREG(eflags);
-      _SETREG(cs);
-      _SETREG(ss);
-      _SETREG(ds);
-      _SETREG(es);
-      _SETREG(fs);
-      _SETREG(gs);
-#undef _SETREG
-    }
+    auto set = [&](uint32_t lldbReg, uint32_t gdbReg,
+                   const GPRegisterValue &value) {
+      regs[forLLDB ? lldbReg : gdbReg] = value;
+    };
+
+    set(reg_lldb_rax, reg_gdb_rax, _REGVALUE(rax));
+    set(reg_lldb_rcx, reg_gdb_rcx, _REGVALUE(rcx));
+    set(reg_lldb_rdx, reg_gdb_rdx, _REGVALUE(rdx));
+    set(reg_lldb_rbx, reg_gdb_rbx, _REGVALUE(rbx));
+    set(reg_lldb_rsi, reg_gdb_rsi, _REGVALUE(rsi));
+    set(reg_lldb_rdi, reg_gdb_rdi, _REGVALUE(rdi));
+    set(reg_lldb_rsp, reg_gdb_rsp, _REGVALUE(rsp));
+    set(reg_lldb_rbp, reg_gdb_rbp, _REGVALUE(rbp));
+    set(reg_lldb_r8, reg_gdb_r8, _REGVALUE(r8));
+    set(reg_lldb_r9, reg_gdb_r9, _REGVALUE(r9));
+    set(reg_lldb_r10, reg_gdb_r10, _REGVALUE(r10));
+    set(reg_lldb_r11, reg_gdb_r11, _REGVALUE(r11));
+    set(reg_lldb_r12, reg_gdb_r12, _REGVALUE(r12));
+    set(reg_lldb_r13, reg_gdb_r13, _REGVALUE(r13));
+    set(reg_lldb_r14, reg_gdb_r14, _REGVALUE(r14));
+    set(reg_lldb_r15, reg_gdb_r15, _REGVALUE(r15));
+    set(reg_lldb_rip, reg_gdb_rip, _REGVALUE(rip));
+    set(reg_lldb_eflags, reg_gdb_eflags, _REGVALUE(eflags));
+    set(reg_lldb_cs, reg_gdb_cs, _REGVALUE(cs));
+    set(reg_lldb_ss, reg_gdb_ss, _REGVALUE(ss));
+    set(reg_lldb_ds, reg_gdb_ds, _REGVALUE(ds));
+    set(reg_lldb_es, reg_gdb_es, _REGVALUE(es));
+    set(reg_lldb_fs, reg_gdb_fs, _REGVALUE(fs));
+    set(reg_lldb_gs, reg_gdb_gs, _REGVALUE(gs));
   }
 #undef _REGVALUE
 

--- a/Headers/DebugServer2/GDBRemote/ProtocolInterpreter.h
+++ b/Headers/DebugServer2/GDBRemote/ProtocolInterpreter.h
@@ -22,8 +22,9 @@ class ProtocolInterpreter : public PacketProcessorDelegate {
 public:
   struct Handler {
     typedef std::vector<Handler> Collection;
-    typedef void (ProtocolHandler::*Callback)(Handler const &handler,
-                                              std::string const &data);
+    typedef void (ProtocolHandler::*Callback)(Handler const &,
+                                               std::string const &);
+    using CallbackType = Callback;
 
     enum Mode { kModeEquals, kModeStartsWith };
 

--- a/Headers/DebugServer2/GDBRemote/ProtocolInterpreter.h
+++ b/Headers/DebugServer2/GDBRemote/ProtocolInterpreter.h
@@ -12,6 +12,8 @@
 
 #include "DebugServer2/GDBRemote/PacketProcessor.h"
 
+#include <string_view>
+
 namespace ds2 {
 namespace GDBRemote {
 
@@ -33,7 +35,7 @@ public:
     ProtocolHandler *handler;
     Callback callback;
 
-    int compare(std::string const &command) const;
+    int compare(std::string_view command) const;
   };
 
 private:
@@ -51,7 +53,7 @@ public:
   }
 
 public:
-  void onCommand(std::string const &command, std::string const &arguments);
+  void onCommand(std::string_view command, std::string_view arguments);
 
 public:
   bool registerHandler(Handler const &handler);
@@ -65,7 +67,7 @@ public:
   }
 
 private:
-  Handler const *findHandler(std::string const &command,
+  Handler const *findHandler(std::string_view command,
                              size_t &commandLength) const;
 
 public:

--- a/Headers/DebugServer2/GDBRemote/Types.h
+++ b/Headers/DebugServer2/GDBRemote/Types.h
@@ -64,8 +64,9 @@ private:
   void reasonToString(std::string &key, std::string &val,
                       CompatibilityMode mode) const;
   std::string encodeInfo(CompatibilityMode mode, bool listThreads) const;
-  void encodeRegisters(std::map<std::string, std::string> &regs,
-                       bool hexIndex) const;
+  std::string formatRegisterNumber(uint64_t regno, bool hexIndex) const;
+  std::string formatRegisterValue(const Architecture::GPRegisterValue &value)
+      const;
   std::string encodeRegisters() const;
 
 public:

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -141,12 +141,12 @@ ErrorCode DebugSessionImplBase::onQuerySupported(
 
   auto addFeature = [&localFeatures](char const *name, Feature::Flag flag,
                                      char const *value = nullptr) {
-    Feature feature;
+    localFeatures.emplace_back();
+    Feature &feature = localFeatures.back();
     feature.name = name;
     feature.flag = flag;
     if (value != nullptr)
       feature.value = value;
-    localFeatures.push_back(feature);
   };
 
   auto enable =

--- a/Sources/GDBRemote/ProtocolInterpreter.cpp
+++ b/Sources/GDBRemote/ProtocolInterpreter.cpp
@@ -56,6 +56,9 @@ CommandRange splitCommand(const std::string &data) {
     if (end != std::string::npos) {
       range.first = end;
       range.second = end + 1;
+    } else {
+      // No delimiter found; command spans entire packet.
+      range.first = data.length();
     }
   } else if (data[0] == 'b') {
     //
@@ -81,6 +84,9 @@ CommandRange splitCommand(const std::string &data) {
     if (end != std::string::npos) {
       range.first = end;
       range.second = end + 1;
+    } else {
+      // No delimiter found; command spans entire packet.
+      range.first = data.length();
     }
   } else {
     //
@@ -89,7 +95,7 @@ CommandRange splitCommand(const std::string &data) {
     range.first = 1;
   }
 
-  if (range.second == std::string::npos && range.first < data.length())
+  if (range.second == std::string::npos && range.first <= data.length())
     range.second = range.first;
 
   return range;

--- a/Sources/GDBRemote/ProtocolInterpreter.cpp
+++ b/Sources/GDBRemote/ProtocolInterpreter.cpp
@@ -17,11 +17,15 @@
 #include <cstring>
 #include <iomanip>
 #include <sstream>
+#include <string_view>
+#include <utility>
 
 namespace ds2 {
 namespace GDBRemote {
 
-static std::string EscapeForTerm(std::string const &s) {
+namespace {
+
+std::string EscapeForTerm(std::string const &s) {
   std::ostringstream ss;
   for (char n : s) {
     unsigned c = static_cast<unsigned>(n & 0xff);
@@ -34,6 +38,64 @@ static std::string EscapeForTerm(std::string const &s) {
   }
   return ss.str();
 }
+
+using CommandRange = std::pair<size_t, size_t>;
+
+CommandRange splitCommand(const std::string &data) {
+  CommandRange range = {std::string::npos, std::string::npos};
+
+  if (data.empty())
+    return range;
+
+  if (data[0] == 'v' || data[0] == 'q' || data[0] == 'Q') {
+    //
+    // Commands starting with 'v', 'q', or 'Q' are terminated by
+    // one of: ',' (comma), ':' (colon), or ';' (semi-colon).
+    //
+    size_t end = data.find_first_of(",:;");
+    if (end != std::string::npos) {
+      range.first = end;
+      range.second = end + 1;
+    }
+  } else if (data[0] == 'b') {
+    //
+    // Commands starting with 'b' may be two chars long; only 'bc'
+    // and 'bs' are known.
+    //
+    range.first = (data.length() == 2 && (data[1] == 'c' || data[1] == 's'))
+                      ? 2
+                      : 1;
+  } else if (data[0] == '_') {
+    //
+    // Commands starting with '_' may be two chars long; only '_M'
+    // and '_m' are known.
+    //
+    range.first = (data.length() > 1 && (data[1] == 'M' || data[1] == 'm'))
+                      ? 2
+                      : 1;
+  } else if (data[0] == 'j') {
+    //
+    // Commands starting with 'j' are terminated by ':' (colon).
+    //
+    size_t end = data.find_first_of(":");
+    if (end != std::string::npos) {
+      range.first = end;
+      range.second = end + 1;
+    }
+  } else {
+    //
+    // Any other command is one character.
+    //
+    range.first = 1;
+  }
+
+  if (range.second == std::string::npos && range.first < data.length())
+    range.second = range.first;
+
+  return range;
+}
+
+} // namespace
 
 ProtocolInterpreter::ProtocolInterpreter() : _session(nullptr) {}
 
@@ -73,67 +135,13 @@ void ProtocolInterpreter::onPacketData(std::string const &data, bool valid) {
   // Extract the command and arguments to pass down to the
   // handler.
   //
-  size_t command_end = std::string::npos;
-  size_t args_start = std::string::npos;
-  if (data[0] == 'v' || data[0] == 'q' || data[0] == 'Q') {
-    //
-    // The commands starting with 'v', 'q' or 'Q' may be terminated
-    // by one of the following separator: , (comma), : (colon) or
-    // ; (semi-colon).
-    //
-    size_t end = data.find_first_of(",:;");
-    if (end != std::string::npos) {
-      command_end = end;
-      args_start = end + 1;
-    }
-  } else if (data[0] == 'b') {
-    //
-    // The commands starting with 'b' may be two chars long; only 'bc'
-    // and 'bs' are known.
-    //
-    if (data.length() == 2 && (data[1] == 'c' || data[1] == 's')) {
-      command_end = 2;
-    } else {
-      command_end = 1;
-    }
-  } else if (data[0] == '_') {
-    //
-    // The commands starting with '_' may be two chars long; only '_M'
-    // and '_m' are known.
-    //
-    if (data.length() > 1 && (data[1] == 'M' || data[1] == 'm')) {
-      command_end = 2;
-    } else {
-      command_end = 1;
-    }
-  } else if (data[0] == 'j') {
-    //
-    // The commands starting with j are terminated with : (colon)
-    //
-    size_t end = data.find_first_of(":");
-    if (end != std::string::npos) {
-      command_end = end;
-      args_start = end + 1;
-    }
-  } else {
-    //
-    // Any other command is long just one char.
-    //
-    command_end = 1;
-  }
+  CommandRange range = splitCommand(data);
 
-  if (args_start == std::string::npos && command_end < data.length()) {
-    //
-    // Arguments follow the command with no separator.
-    //
-    args_start = command_end;
-  }
-
-  std::string command = data.substr(0, command_end);
-  std::string args;
-  if (args_start != std::string::npos) {
-    args = data.substr(args_start);
-  }
+  std::string_view command(data.data(), range.first);
+  std::string_view args;
+  if (range.second != std::string::npos)
+    args = std::string_view(data.data() + range.second,
+                            data.length() - range.second);
 
   //
   // Find the handler and execute it.
@@ -150,12 +158,13 @@ void ProtocolInterpreter::onInvalidData(std::string const &data) {
   _session->onInvalidData(data);
 }
 
-void ProtocolInterpreter::onCommand(std::string const &command,
-                                    std::string const &arguments) {
+void ProtocolInterpreter::onCommand(std::string_view command,
+                                    std::string_view arguments) {
   size_t commandLength;
   Handler const *handler = findHandler(command, commandLength);
   if (handler == nullptr) {
-    DS2LOG(Packet, "handler for command '%s' unknown", command.c_str());
+    std::string commandString(command);
+    DS2LOG(Packet, "handler for command '%s' unknown", commandString.c_str());
 
     //
     // The handler couldn't be found, we don't support this packet.
@@ -169,10 +178,10 @@ void ProtocolInterpreter::onCommand(std::string const &command,
     //
     // Command has part of the argument, LLDB doesn't use separators :(
     //
-    extra = command.substr(commandLength);
+    extra.assign(command.data() + commandLength, command.length() - commandLength);
   }
 
-  extra += arguments;
+  extra.append(arguments.data(), arguments.length());
 
   if (extra.find_first_of("*}") != std::string::npos) {
     extra = Unescape(extra);
@@ -187,27 +196,26 @@ bool ProtocolInterpreter::registerHandler(Handler const &handler) {
       handler.callback == nullptr)
     return false;
 
-  size_t commandLength;
-  if (findHandler(handler.command, commandLength))
+  auto it = std::lower_bound(
+      _handlers.begin(), _handlers.end(), handler.command,
+      [](Handler const &existing, std::string const &command) -> bool {
+        return existing.compare(command) < 0;
+      });
+
+  if (it != _handlers.end() && it->compare(handler.command) == 0)
     return false;
 
-  _handlers.push_back(handler);
-
-  // We need to sort the handlers vector.
-  std::sort(_handlers.begin(), _handlers.end(),
-            [](Handler const &a, Handler const &b) -> bool {
-              return (a.command < b.command);
-            });
+  _handlers.insert(it, handler);
 
   return true;
 }
 
 ProtocolInterpreter::Handler const *
-ProtocolInterpreter::findHandler(std::string const &command,
+ProtocolInterpreter::findHandler(std::string_view command,
                                  size_t &commandLength) const {
   auto it = std::lower_bound(
       _handlers.begin(), _handlers.end(), command,
-      [](Handler const &handler, std::string const &command) -> bool {
+      [](Handler const &handler, std::string_view command) -> bool {
         return handler.compare(command) < 0;
       });
 
@@ -220,7 +228,7 @@ ProtocolInterpreter::findHandler(std::string const &command,
   return handler;
 }
 
-int ProtocolInterpreter::Handler::compare(std::string const &command_) const {
+int ProtocolInterpreter::Handler::compare(std::string_view command_) const {
   if (mode == Handler::kModeEquals) {
     return command.compare(command_);
   } else {

--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -36,24 +36,29 @@ namespace GDBRemote {
 
 Session::Session(CompatibilityMode mode)
     : SessionBase(mode), _threadsInStopReply(false) {
-#define REGISTER_HANDLER(MODE, MESSAGE, HANDLER)                               \
-  do {                                                                         \
-    bool REGISTER_HANDLER_result = interpreter().registerHandler(              \
-        MODE, MESSAGE, this, &Session::Handle_##HANDLER);                      \
-    DS2ASSERT(REGISTER_HANDLER_result);                                        \
-  } while (0)
+  auto registerHandler = [this](ProtocolInterpreter::Handler::Mode mode,
+                                char const *command,
+                                void (Session::*callback)(
+                                    ProtocolInterpreter::Handler const &,
+                                    std::string const &)) {
+    bool result = interpreter().registerHandler(mode, command, this, callback);
+    DS2ASSERT(result);
+  };
 
-#define REGISTER_HANDLER_EQUALS_2(MESSAGE, HANDLER)                            \
+#define REGISTER_HANDLER(MODE, MESSAGE, HANDLER)                              \
+  registerHandler(MODE, MESSAGE, &Session::Handle_##HANDLER)
+
+#define REGISTER_HANDLER_EQUALS_2(MESSAGE, HANDLER)                           \
   REGISTER_HANDLER(ProtocolInterpreter::Handler::kModeEquals, MESSAGE, HANDLER)
 
-#define REGISTER_HANDLER_EQUALS_1(HANDLER)                                     \
+#define REGISTER_HANDLER_EQUALS_1(HANDLER)                                    \
   REGISTER_HANDLER_EQUALS_2(#HANDLER, HANDLER)
 
-#define REGISTER_HANDLER_STARTS_WITH_2(MESSAGE, HANDLER)                       \
-  REGISTER_HANDLER(ProtocolInterpreter::Handler::kModeStartsWith, MESSAGE,     \
+#define REGISTER_HANDLER_STARTS_WITH_2(MESSAGE, HANDLER)                      \
+  REGISTER_HANDLER(ProtocolInterpreter::Handler::kModeStartsWith, MESSAGE,    \
                    HANDLER)
 
-#define REGISTER_HANDLER_STARTS_WITH_1(HANDLER)                                \
+#define REGISTER_HANDLER_STARTS_WITH_1(HANDLER)                               \
   REGISTER_HANDLER_STARTS_WITH_2(#HANDLER, HANDLER)
 
   REGISTER_HANDLER_EQUALS_2("\x03", ControlC);
@@ -181,6 +186,7 @@ Session::Session(CompatibilityMode mode)
 #undef REGISTER_HANDLER_STARTS_WITH_2
 #undef REGISTER_HANDLER_EQUALS_1
 #undef REGISTER_HANDLER_EQUALS_2
+#undef REGISTER_HANDLER
 }
 
 bool Session::ParseList(std::string const &string, char separator,

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -38,6 +38,34 @@ using ds2::Utils::Stringify;
 namespace ds2 {
 namespace GDBRemote {
 
+namespace {
+
+const char *EndianName(Endian endian) {
+  switch (endian) {
+  case kEndianBig:
+    return "big";
+  case kEndianLittle:
+    return "little";
+  case kEndianPDP:
+    return "pdp";
+  default:
+    return "unknown";
+  }
+}
+
+std::string JoinRegisterNumbers(const std::vector<uint32_t> &registers,
+                                bool decimal) {
+  std::ostringstream ss;
+  for (size_t n = 0; n < registers.size(); ++n) {
+    if (n != 0)
+      ss << ',';
+    ss << (decimal ? std::dec : std::hex) << registers[n] << std::dec;
+  }
+  return ss.str();
+}
+
+} // namespace
+
 //
 // feature+ or feature- or feature? or feature=value
 //
@@ -281,7 +309,7 @@ std::string StopInfo::encodeInfo(CompatibilityMode mode,
   if (!threadName.empty()) {
     ss << ';' << "name:" << threadName;
   }
-  if (!(core < 0)) {
+  if (core >= 0) {
     ss << ';' << "core:" << core;
   }
 
@@ -347,41 +375,39 @@ std::string StopInfo::encodeInfo(CompatibilityMode mode,
   return ss.str();
 }
 
-void StopInfo::encodeRegisters(std::map<std::string, std::string> &regs,
-                               bool hexIndex) const {
-  for (auto &reg : registers) {
-    std::stringstream regNum;
-    std::stringstream regVal;
-    size_t regsize = reg.second.size << 3;
-
-    if (hexIndex) {
-      regNum << HEX(2) << (reg.first & 0xff);
-    } else {
-      regNum << DEC << reg.first;
-    }
-
-#if defined(ENDIAN_BIG)
-    regVal << HEX(regsize >> 2) << reg.second.value;
-#else
-    regVal << HEX(regsize >> 2) << (Swap64(reg.second.value) >> (64 - regsize));
-#endif
-
-    regs.insert(std::make_pair(regNum.str(), regVal.str()));
+std::string StopInfo::formatRegisterNumber(uint64_t regno, bool hexIndex) const {
+  std::ostringstream ss;
+  if (hexIndex) {
+    ss << HEX(2) << (regno & 0xff);
+  } else {
+    ss << DEC << regno;
   }
+  return ss.str();
+}
+
+std::string
+StopInfo::formatRegisterValue(const Architecture::GPRegisterValue &value) const {
+  std::ostringstream ss;
+  size_t regsize = value.size << 3;
+#if defined(ENDIAN_BIG)
+  ss << HEX(regsize >> 2) << value.value;
+#else
+  ss << HEX(regsize >> 2) << (Swap64(value.value) >> (64 - regsize));
+#endif
+  return ss.str();
 }
 
 std::string StopInfo::encodeRegisters() const {
   std::ostringstream ss;
   bool first = true;
-  std::map<std::string, std::string> regs;
-  encodeRegisters(regs, true);
 
-  for (auto &reg : regs) {
+  for (const auto &reg : registers) {
     if (!first) {
       ss << ';';
     }
 
-    ss << reg.first << ':' << reg.second;
+    ss << formatRegisterNumber(reg.first, true) << ':'
+       << formatRegisterValue(reg.second);
 
     first = false;
   }
@@ -523,11 +549,9 @@ JSDictionary *StopInfo::encodeJson() const {
   }
 
   auto regSet = JSDictionary::New();
-  std::map<std::string, std::string> regs;
-  encodeRegisters(regs, false);
-
-  for (auto const &reg : regs) {
-    regSet->set(reg.first, JSString::New(reg.second));
+  for (const auto &reg : registers) {
+    regSet->set(formatRegisterNumber(reg.first, false),
+                JSString::New(formatRegisterValue(reg.second)));
   }
 
   threadObj->set("registers", regSet);
@@ -588,22 +612,7 @@ std::string HostInfo::encode() const {
   if (!hostName.empty()) {
     ss << "hostname:" << ToHex(hostName) << ';';
   }
-  ss << "endian:";
-  switch (endian) {
-  case kEndianBig:
-    ss << "big";
-    break;
-  case kEndianLittle:
-    ss << "little";
-    break;
-  case kEndianPDP:
-    ss << "pdp";
-    break;
-  default:
-    ss << "unknown";
-    break;
-  }
-  ss << ';';
+  ss << "endian:" << EndianName(endian) << ';';
   ss << "ptrsize:" << pointerSize << ';';
   ss << "watchpoint_exceptions_received:"
      << (watchpointExceptionsReceivedBefore ? "before" : "after") << ';';
@@ -667,22 +676,7 @@ std::string ProcessInfo::encode(CompatibilityMode mode,
         ss << "cpusubtype:" << HEX0 << nativeCPUSubType << ';';
       }
     }
-    ss << "endian:";
-    switch (endian) {
-    case kEndianBig:
-      ss << "big";
-      break;
-    case kEndianLittle:
-      ss << "little";
-      break;
-    case kEndianPDP:
-      ss << "pdp";
-      break;
-    default:
-      ss << "unknown";
-      break;
-    }
-    ss << ';';
+    ss << "endian:" << EndianName(endian) << ';';
     ss << "ptrsize:" << pointerSize << ';';
     ss << "vendor:" << osVendor << ";";
     ss << "ostype:" << osType << ";";
@@ -760,84 +754,84 @@ std::string RegisterInfo::encode(int xmlSet) const {
     return std::string();
   }
 
-  std::vector<std::pair<std::string, std::string>> regInfo;
-
-  regInfo.push_back(std::make_pair("name", registerName));
-  if (!alternateName.empty())
-    regInfo.push_back(
-        std::make_pair(xml ? "altname" : "alt-name", alternateName));
-
-  regInfo.push_back(std::make_pair("bitsize", ds2::Utils::ToString(bitSize)));
-  regInfo.push_back(std::make_pair(
-      "offset", ds2::Utils::ToString(byteOffset < 0 ? 0 : byteOffset)));
-
-  if (encodingName != nullptr)
-    regInfo.push_back(std::make_pair("encoding", encodingName));
-
-  if (formatName != nullptr)
-    regInfo.push_back(std::make_pair("format", formatName));
-
-  if (!setName.empty()) {
-    if (xml)
-      regInfo.push_back(
-          std::make_pair("group_id", ds2::Utils::ToString(xmlSet)));
-    else
-      regInfo.push_back(std::make_pair("set", setName));
-  }
-
-  if (xml) {
-    regInfo.push_back(std::make_pair("regnum", ds2::Utils::ToString(regno)));
-  }
-
-  if (!(ehframeRegisterIndex < 0))
-    regInfo.push_back(
-        std::make_pair(xml ? "ehframe_regnum" : "ehframe",
-                       ds2::Utils::ToString(ehframeRegisterIndex)));
-
-  if (!(dwarfRegisterIndex < 0))
-    regInfo.push_back(std::make_pair(xml ? "dwarf_regnum" : "dwarf",
-                                     ds2::Utils::ToString(dwarfRegisterIndex)));
-
-  if (!genericName.empty())
-    regInfo.push_back(std::make_pair("generic", genericName));
-
-  if (!containerRegisters.empty()) {
-    std::ostringstream contStream;
-    for (size_t n = 0; n < containerRegisters.size(); n++) {
-      if (n != 0)
-        contStream << ',';
-      contStream << (xml ? std::dec : std::hex) << containerRegisters[n]
-                 << std::dec;
-    }
-    regInfo.push_back(std::make_pair(xml ? "value_regnums" : "container-regs",
-                                     contStream.str()));
-  }
-
-  if (!invalidateRegisters.empty()) {
-    std::ostringstream invStream;
-    for (size_t n = 0; n < invalidateRegisters.size(); n++) {
-      if (n != 0)
-        invStream << ',';
-      invStream << (xml ? std::dec : std::hex) << invalidateRegisters[n]
-                << std::dec;
-    }
-    regInfo.push_back(std::make_pair(
-        xml ? "invalidate_regnums" : "invalidate-regs", invStream.str()));
-  }
-
   std::ostringstream ss;
-  if (xml)
+  if (xml) {
     ss << "<reg ";
 
-  for (auto const &entry : regInfo) {
-    if (xml)
-      ss << entry.first << "=" << '"' << entry.second << '"' << ' ';
-    else
-      ss << entry.first << ":" << entry.second << ";";
-  }
+    auto append = [&ss](char const *key, auto const &value) {
+      ss << key << "=" << '"' << value << '"' << ' ';
+    };
 
-  if (xml)
+    append("name", registerName);
+    if (!alternateName.empty())
+      append("altname", alternateName);
+
+    append("bitsize", bitSize);
+    append("offset", byteOffset < 0 ? 0 : byteOffset);
+
+    if (encodingName != nullptr)
+      append("encoding", encodingName);
+
+    if (formatName != nullptr)
+      append("format", formatName);
+
+    if (!setName.empty())
+      append("group_id", xmlSet);
+
+    append("regnum", regno);
+
+    if (ehframeRegisterIndex >= 0)
+      append("ehframe_regnum", ehframeRegisterIndex);
+
+    if (dwarfRegisterIndex >= 0)
+      append("dwarf_regnum", dwarfRegisterIndex);
+
+    if (!genericName.empty())
+      append("generic", genericName);
+
+    if (!containerRegisters.empty())
+      append("value_regnums", JoinRegisterNumbers(containerRegisters, true));
+
+    if (!invalidateRegisters.empty())
+      append("invalidate_regnums", JoinRegisterNumbers(invalidateRegisters, true));
+
     ss << "/>";
+  } else {
+    auto append = [&ss](char const *key, auto const &value) {
+      ss << key << ":" << value << ";";
+    };
+
+    append("name", registerName);
+    if (!alternateName.empty())
+      append("alt-name", alternateName);
+
+    append("bitsize", bitSize);
+    append("offset", byteOffset < 0 ? 0 : byteOffset);
+
+    if (encodingName != nullptr)
+      append("encoding", encodingName);
+
+    if (formatName != nullptr)
+      append("format", formatName);
+
+    if (!setName.empty())
+      append("set", setName);
+
+    if (ehframeRegisterIndex >= 0)
+      append("ehframe", ehframeRegisterIndex);
+
+    if (dwarfRegisterIndex >= 0)
+      append("dwarf", dwarfRegisterIndex);
+
+    if (!genericName.empty())
+      append("generic", genericName);
+
+    if (!containerRegisters.empty())
+      append("container-regs", JoinRegisterNumbers(containerRegisters, false));
+
+    if (!invalidateRegisters.empty())
+      append("invalidate-regs", JoinRegisterNumbers(invalidateRegisters, false));
+  }
 
   return ss.str();
 }


### PR DESCRIPTION
This pull request refactors and modernizes several core areas of the GDB remote protocol implementation, focusing on improved command parsing, handler registration, and register encoding. Key changes include switching to `std::string_view` for command handling, centralizing and simplifying command parsing logic, and updating register formatting for clarity and maintainability.

### Protocol Command Handling and Parsing

* Refactored command extraction logic in `ProtocolInterpreter` to use a new `splitCommand` helper, centralizing all command/argument parsing and reducing code duplication. The code now uses `std::string_view` for efficient string handling throughout the command dispatch path. [[1]](diffhunk://#diff-e09add2d0234b52f192c5ecadcf28d62cd91ae2ce3ba7804705114b327532ab5R42-R99) [[2]](diffhunk://#diff-e09add2d0234b52f192c5ecadcf28d62cd91ae2ce3ba7804705114b327532ab5L76-R144) [[3]](diffhunk://#diff-e09add2d0234b52f192c5ecadcf28d62cd91ae2ce3ba7804705114b327532ab5L153-R167) [[4]](diffhunk://#diff-e09add2d0234b52f192c5ecadcf28d62cd91ae2ce3ba7804705114b327532ab5L172-R184) [[5]](diffhunk://#diff-a7409deb0f94adf116d48911a5ec3bdcbe4d7b85687acd35ec52fa8adf40787aR15-R16) [[6]](diffhunk://#diff-a7409deb0f94adf116d48911a5ec3bdcbe4d7b85687acd35ec52fa8adf40787aL35-R37) [[7]](diffhunk://#diff-a7409deb0f94adf116d48911a5ec3bdcbe4d7b85687acd35ec52fa8adf40787aL53-R55) [[8]](diffhunk://#diff-a7409deb0f94adf116d48911a5ec3bdcbe4d7b85687acd35ec52fa8adf40787aL67-R69) [[9]](diffhunk://#diff-e09add2d0234b52f192c5ecadcf28d62cd91ae2ce3ba7804705114b327532ab5L223-R231)

* Improved handler registration in `ProtocolInterpreter` to use insertion via `std::lower_bound` for efficient lookup and to maintain sorted order, removing the need for post-insertion sorting.

* Updated handler comparison and lookup to also use `std::string_view`, improving performance and reducing unnecessary allocations. [[1]](diffhunk://#diff-e09add2d0234b52f192c5ecadcf28d62cd91ae2ce3ba7804705114b327532ab5L223-R231) [[2]](diffhunk://#diff-a7409deb0f94adf116d48911a5ec3bdcbe4d7b85687acd35ec52fa8adf40787aL35-R37) [[3]](diffhunk://#diff-a7409deb0f94adf116d48911a5ec3bdcbe4d7b85687acd35ec52fa8adf40787aL67-R69)

### Register Encoding and Formatting

* Refactored `StopInfo` register encoding: split out register number and value formatting into dedicated methods, and updated all usages to leverage these helpers for both string and JSON output. This makes the code more modular and easier to maintain. [[1]](diffhunk://#diff-06886b3a8244da7211aa57f80f990e265f1a41a533dc204a4f5eb875211bea2aL67-R69) [[2]](diffhunk://#diff-53bde76b10e86772d5736684448e8956dd8a611fa9ae03c246e46b9b2825c0c5L350-R410) [[3]](diffhunk://#diff-53bde76b10e86772d5736684448e8956dd8a611fa9ae03c246e46b9b2825c0c5L526-R554)

* Fixed the logic for encoding the CPU core number in `StopInfo::encodeInfo` to properly emit the field only when the core is non-negative.

### CPU Register State Handling

* Simplified `getStopGPState` in both `CPUState` (x86) and `CPUState64` (x86_64) to use a lambda for register assignment, eliminating duplicated code and improving maintainability. [[1]](diffhunk://#diff-2ee157683b17491fc08b4beca03aee789642a851447321b85e747864cb499c1aL195-R215) [[2]](diffhunk://#diff-9cdbb4b10d1293661e93c19f5c4c21d59726e83f7a3b3d8c41d52eb795127fe1L252-R280)

### Miscellaneous

* Added utility functions for endian name formatting and register number joining in `Structures.cpp` to support other refactorings.

* Minor bugfix in feature addition logic in `DebugSessionImplBase::onQuerySupported` to avoid unnecessary copies.

These changes collectively improve the clarity, efficiency, and maintainability of the GDB remote protocol codebase.