### PR TITLE
Implement real ARM64 hardware watchpoint support for Linux and Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,11 @@ if(WIN32 OR WINDOWS_STORE)
     Sources/Utils/Windows/Daemon.cpp
     Sources/Utils/Windows/FaultHandler.cpp
     Sources/Utils/Windows/Stringify.cpp)
+
+  if(DS2_ARCHITECTURE MATCHES "ARM64")
+    target_sources(ds2 PRIVATE
+      Sources/Core/Windows/ARM64/HardwareBreakpointManager.cpp)
+  endif()
 else()
   # Assumes that any non-Windows platform is POSIX.
   target_sources(ds2 PRIVATE
@@ -347,6 +352,11 @@ else()
       Sources/Target/Linux/Process.cpp
       Sources/Target/Linux/Thread.cpp
       Sources/Target/Linux/${DS2_ARCHITECTURE}/Process${DS2_ARCHITECTURE}.cpp)
+
+    if(DS2_ARCHITECTURE MATCHES "ARM64")
+      target_sources(ds2 PRIVATE
+        Sources/Core/Linux/ARM64/HardwareBreakpointManager.cpp)
+    endif()
   elseif(APPLE)
     target_sources(ds2 PRIVATE
       Sources/Host/Darwin/LibProc.cpp
@@ -360,6 +370,11 @@ else()
       Sources/Target/Darwin/Thread.cpp
       Sources/Target/Darwin/${DS2_ARCHITECTURE}/Process${DS2_ARCHITECTURE}.cpp
       Sources/Target/Darwin/${DS2_ARCHITECTURE}/Thread${DS2_ARCHITECTURE}.cpp)
+
+    if(DS2_ARCHITECTURE MATCHES "ARM64")
+      target_sources(ds2 PRIVATE
+        Sources/Core/Darwin/ARM64/HardwareBreakpointManager.cpp)
+    endif()
   elseif("${BSD}" STREQUAL "FreeBSD")
     target_sources(ds2 PRIVATE
       Sources/Host/FreeBSD/Platform.cpp
@@ -370,6 +385,11 @@ else()
       Sources/Target/FreeBSD/Process.cpp
       Sources/Target/FreeBSD/Thread.cpp
       Sources/Target/FreeBSD/${DS2_ARCHITECTURE}/Process${DS2_ARCHITECTURE}.cpp)
+
+    if(DS2_ARCHITECTURE MATCHES "ARM64")
+      target_sources(ds2 PRIVATE
+        Sources/Core/FreeBSD/ARM64/HardwareBreakpointManager.cpp)
+    endif()
   endif()
 endif()
 

--- a/Headers/DebugServer2/Architecture/ARM64/HardwareWatchpoint.h
+++ b/Headers/DebugServer2/Architecture/ARM64/HardwareWatchpoint.h
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#pragma once
+
+#include "DebugServer2/Core/BreakpointManager.h"
+#include "DebugServer2/Core/ErrorCodes.h"
+#include "DebugServer2/Types.h"
+
+namespace ds2 {
+
+//
+// DBGWVRn_EL1/DBGWCRn_EL1 (or Wvr[]/Wcr[] on Windows) bit layout, shared by
+// every OS-specific HardwareBreakpointManager implementation for ARM64. The
+// encoding mirrors LLDB's own client-side implementation for the same
+// hardware (NativeRegisterContextDBReg_arm64.cpp /
+// NativeRegisterContextLinux_arm64dbreg.cpp), which is the most authoritative
+// available cross-check for the exact encoding short of the ARMv8-A
+// Architecture Reference Manual itself:
+//
+//   bit    0    : E    (enable)
+//   bits 2:1    : PAC  (privilege access control; 0b10, EL0-only, is what
+//                       LLDB programs and is what we mirror here)
+//   bits 4:3    : LSC  (load/store control: 01 for load/read, 10 for
+//                       store/write, 11 for either)
+//   bits 12:5   : BAS  (byte address select, one bit per watched byte
+//                       within the 8-byte-aligned doubleword pointed at by
+//                       the value register)
+//
+
+constexpr uint32_t kARM64WatchpointEnable = 1u << 0;
+constexpr uint32_t kARM64WatchpointPAC = 0x2u << 1;
+constexpr uint32_t kARM64WatchpointLSCShift = 3;
+constexpr uint32_t kARM64WatchpointBASShift = 5;
+
+// Computes the DBGWVRn_EL1/DBGWCRn_EL1 (or Wvr[]/Wcr[] on Windows) pair that
+// implements a watchpoint over [address, address + size). `address`/`size`
+// are validated (size in {1, 2, 4, 8}, and the range fits within a single
+// 8-byte watchpoint granule) by HardwareBreakpointManager::isValid() before
+// this is ever reached.
+inline ErrorCode ComputeARM64WatchpointControl(Address const &address,
+                                               size_t size,
+                                               BreakpointManager::Mode mode,
+                                               uint64_t &wvr, uint32_t &wcr) {
+  uint32_t lsc;
+  switch (static_cast<int>(mode)) {
+  case BreakpointManager::kModeWrite:
+    lsc = 0x2;
+    break;
+  case BreakpointManager::kModeRead:
+    lsc = 0x1;
+    break;
+  case BreakpointManager::kModeRead | BreakpointManager::kModeWrite:
+    lsc = 0x3;
+    break;
+  default:
+    return kErrorInvalidArgument;
+  }
+
+  uint64_t addr = address;
+  unsigned offset = static_cast<unsigned>(addr & 0x7);
+  unsigned span = offset + static_cast<unsigned>(size);
+  if (span > 8) {
+    // Does not fit in a single hardware watchpoint slot.
+    return kErrorInvalidArgument;
+  }
+
+  // BAS only needs to be a contiguous run of bits within the 8-byte
+  // granule; the hardware does not require that run to itself be aligned
+  // to its own size (this matches the Linux kernel's own arm64
+  // hw_breakpoint validation, which simply shifts the size-based mask by
+  // the raw offset). So the exact requested range can always be expressed
+  // directly: e.g. a 2-byte watchpoint at the granule's byte 1 is BAS 0x06
+  // (bytes 1-2), not a widened 4-byte range starting at byte 0.
+  uint32_t bas = static_cast<uint32_t>((1u << size) - 1) << offset;
+
+  wvr = addr & ~static_cast<uint64_t>(0x7);
+  wcr = kARM64WatchpointEnable | kARM64WatchpointPAC |
+        (lsc << kARM64WatchpointLSCShift) | (bas << kARM64WatchpointBASShift);
+  return kSuccess;
+}
+
+} // namespace ds2

--- a/Headers/DebugServer2/Core/HardwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/HardwareBreakpointManager.h
@@ -12,6 +12,7 @@
 
 #include "DebugServer2/Core/BreakpointManager.h"
 
+#include <unordered_map>
 #include <unordered_set>
 
 namespace ds2 {
@@ -76,6 +77,18 @@ protected:
   virtual ErrorCode disableDebugCtrlReg(uint64_t &ctrlReg, int idx);
   virtual ErrorCode enableDebugCtrlReg(uint64_t &ctrlReg, int idx, Mode mode,
                                        int size);
+#endif
+
+#if defined(ARCH_ARM64) && defined(OS_WIN32)
+protected:
+  // Last known contents of each enabled watchpoint's memory range, keyed by
+  // slot index. Windows ARM64 has no hardware signal for "which (if any)
+  // watchpoint actually trapped" (see
+  // Sources/Core/Windows/ARM64/HardwareBreakpointManager.cpp), so hit()
+  // compares against this to tell whether a stop that could be either a
+  // watchpoint or an unrelated explicit step actually touched a watched
+  // byte.
+  std::unordered_map<int, ByteVector> _lastKnownValues;
 #endif
 
 public:

--- a/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
@@ -137,6 +137,20 @@ static inline int personality(unsigned long persona) {
 #endif // !PTRACE_SETHBPREGS
 #endif // ARCH_ARM
 
+// NT_ARM_HW_BREAK/NT_ARM_HW_WATCH (the PTRACE_GETREGSET/SETREGSET note types
+// used to access `struct user_hwdebug_state`, i.e. the DBGBVR/DBGBCR and
+// DBGWVR/DBGWCR hardware breakpoint/watchpoint registers) are normally
+// provided by <linux/elf.h>; shim them in case an older sysroot lacks them.
+#if defined(ARCH_ARM64)
+#if !defined(NT_ARM_HW_BREAK)
+#define NT_ARM_HW_BREAK 0x402
+#endif // !NT_ARM_HW_BREAK
+
+#if !defined(NT_ARM_HW_WATCH)
+#define NT_ARM_HW_WATCH 0x403
+#endif // !NT_ARM_HW_WATCH
+#endif // ARCH_ARM64
+
 #if !defined(PTRACE_GETREGSET)
 #define PTRACE_GETREGSET 0x4204
 #endif // !PTRACE_GETREGSET

--- a/Headers/DebugServer2/Host/Linux/PTrace.h
+++ b/Headers/DebugServer2/Host/Linux/PTrace.h
@@ -14,6 +14,8 @@
 #include "DebugServer2/Host/POSIX/PTrace.h"
 #include "DebugServer2/Utils/Log.h"
 
+#include <vector>
+
 namespace ds2 {
 namespace Host {
 namespace Linux {
@@ -110,6 +112,22 @@ public:
 #if defined(ARCH_ARM64)
 protected:
   int getMaxStoppoints(ProcessThreadId const &ptid, int regSet);
+
+public:
+  // Reads/writes the DBGWVRn_EL1/DBGWCRn_EL1 hardware watchpoint value/control
+  // register pairs (accessed via PTRACE_GETREGSET/SETREGSET with
+  // NT_ARM_HW_WATCH, i.e. `struct user_hwdebug_state`), one entry per
+  // hardware-supported watchpoint slot. `addresses`/`controls` are resized by
+  // readHardwareWatchpointControl() to the number of watchpoint slots the
+  // target actually supports (as reported by dbg_info), which callers should
+  // treat as the authoritative slot count instead of assuming a fixed value.
+  ErrorCode readHardwareWatchpointControl(ProcessThreadId const &ptid,
+                                          std::vector<uint64_t> &addresses,
+                                          std::vector<uint32_t> &controls);
+  ErrorCode
+  writeHardwareWatchpointControl(ProcessThreadId const &ptid,
+                                 std::vector<uint64_t> const &addresses,
+                                 std::vector<uint32_t> const &controls);
 #endif
 };
 } // namespace Linux

--- a/Headers/DebugServer2/Target/Linux/Process.h
+++ b/Headers/DebugServer2/Target/Linux/Process.h
@@ -67,10 +67,17 @@ protected:
   ErrorCode writeCPUState(ThreadId tid, Architecture::CPUState const &state,
                           uint32_t flags = 0);
 
-#if defined(ARCH_ARM)
+#if defined(ARCH_ARM) || defined(ARCH_ARM64)
 public:
   int getMaxBreakpoints() const override;
   int getMaxWatchpoints() const override;
+#endif
+
+// ARM64's hardware watchpoints are always explicitly sized per-slot (there is
+// no architectural equivalent of ARM32's single global maximum watchpoint
+// size), so this is only meaningful for ARM.
+#if defined(ARCH_ARM)
+public:
   int getMaxWatchpointSize() const override;
 #endif
 

--- a/Headers/DebugServer2/Target/Windows/Process.h
+++ b/Headers/DebugServer2/Target/Windows/Process.h
@@ -73,6 +73,11 @@ public:
                            uint64_t *address) override;
   ErrorCode deallocateMemory(uint64_t address, size_t size) override;
 
+#if defined(ARCH_ARM64)
+public:
+  int getMaxWatchpoints() const override;
+#endif
+
 public:
   ErrorCode wait() override;
   ErrorCode afterResume() override;

--- a/Headers/DebugServer2/Target/Windows/Thread.h
+++ b/Headers/DebugServer2/Target/Windows/Thread.h
@@ -12,6 +12,8 @@
 
 #include "DebugServer2/Target/ThreadBase.h"
 
+#include <vector>
+
 namespace ds2 {
 namespace Target {
 namespace Windows {
@@ -45,6 +47,57 @@ public:
 public:
   virtual ErrorCode readCPUState(Architecture::CPUState &state) override;
   virtual ErrorCode writeCPUState(Architecture::CPUState const &state) override;
+
+public:
+  // The ExceptionCode from the most recent EXCEPTION_DEBUG_EVENT delivered
+  // to this thread. On ARM64, there is no equivalent of x86's DR6 status
+  // register to ask "did a debug register actually cause this stop", so
+  // Sources/Core/Windows/ARM64/HardwareBreakpointManager.cpp's hit() uses
+  // this (together with wasExplicitStep(), see below) as the next best
+  // signal to rule out stops that cannot possibly be a watchpoint.
+  DWORD lastExceptionCode() const { return _lastExceptionCode; }
+
+#if defined(ARCH_ARM64)
+public:
+  // Reads/writes the hardware watchpoint value/control register pairs
+  // (Wvr[]/Wcr[] in CONTEXT_DEBUG_REGISTERS). `addresses`/`controls` are
+  // always sized to ARM64_MAX_WATCHPOINTS worth of entries by
+  // readWatchpointRegisters().
+  ErrorCode readWatchpointRegisters(std::vector<uint64_t> &addresses,
+                                    std::vector<uint32_t> &controls);
+  ErrorCode
+  writeWatchpointRegisters(std::vector<uint64_t> const &addresses,
+                           std::vector<uint32_t> const &controls);
+
+public:
+  // PSTATE.SS, per the ARMv8 architecture reference manual. Thread::step()
+  // sets this bit before resuming to arm a single hardware step; the
+  // architectural software-step exception transition clears it again
+  // before the stopped context can be read (precisely so stepping does not
+  // recursively re-trap), so it is not usable after the fact to tell
+  // whether a stop was the completion of that step. Thread::afterResume()
+  // also clears it, for the ordinary case where the step exception is
+  // never taken (e.g. a breakpoint hit first).
+  static constexpr uint64_t kPSTATE_SS = 1ULL << 21;
+
+public:
+  // Set by Thread::step() before it resumes with PSTATE.SS to arm a
+  // hardware single step. updateState(DEBUG_EVENT const&) captures this
+  // (and resets it) into wasExplicitStep() for the resulting stop, since
+  // PSTATE.SS itself cannot be used for that (see above): this is the
+  // ground truth for whether a STATUS_SINGLE_STEP is the expected
+  // completion of a step this side requested, as opposed to an unrelated
+  // watchpoint firing.
+  void setExplicitStep() { _explicitStep = true; }
+  bool wasExplicitStep() const { return _wasExplicitStep; }
+#endif
+
+private:
+  DWORD _lastExceptionCode = 0;
+#if defined(ARCH_ARM64)
+  bool _explicitStep = false;
+  bool _wasExplicitStep = false;
+#endif
 
 protected:
   virtual void updateState() override;

--- a/Sources/Core/ARM/HardwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/HardwareBreakpointManager.cpp
@@ -10,12 +10,88 @@
 
 #include "DebugServer2/Core/HardwareBreakpointManager.h"
 #include "DebugServer2/Target/Process.h"
+#include "DebugServer2/Utils/Log.h"
 
 #include <algorithm>
 
 #define super ds2::BreakpointManager
 
 namespace ds2 {
+
+#if defined(ARCH_ARM64)
+
+//
+// This is a real implementation of ARM64 hardware watchpoints (data
+// breakpoints); the OS-specific register access and hit-detection logic
+// lives alongside the rest of each OS's target support, following the same
+// Host/<OS>/<Arch> and Target/<OS>/<Arch> convention used elsewhere in the
+// tree:
+//
+//   - Sources/Core/Linux/ARM64/HardwareBreakpointManager.cpp
+//   - Sources/Core/Windows/ARM64/HardwareBreakpointManager.cpp
+//   - Sources/Core/Darwin/ARM64/HardwareBreakpointManager.cpp (stub)
+//   - Sources/Core/FreeBSD/ARM64/HardwareBreakpointManager.cpp (stub)
+//
+// This file only holds the parts that do not depend on the host OS: size/mode
+// validation and the shared bit-layout helper in
+// Headers/DebugServer2/Architecture/ARM64/HardwareWatchpoint.h. Hardware
+// *execute* breakpoints (DBGBVR/DBGBCR, accessed via NT_ARM_HW_BREAK on Linux
+// or Bcr/Bvr on Windows) are architecturally a completely separate register
+// file from watchpoints (DBGWVR/DBGWCR, NT_ARM_HW_WATCH / Wcr/Wvr) and are out
+// of scope here; ARM64 execute breakpoints continue to go through
+// SoftwareBreakpointManager, same as before this change.
+//
+
+size_t HardwareBreakpointManager::chooseBreakpointSize(Address const &) const {
+  // Hardware watchpoints are always explicitly sized by the client (the
+  // GDB-remote Z2/Z3/Z4 packets always carry an explicit length), so this
+  // should not normally be reached in practice. Unlike the x86
+  // implementation, return a sensible default instead of asserting.
+  return sizeof(uint64_t);
+}
+
+ErrorCode HardwareBreakpointManager::isValid(Address const &address,
+                                             size_t size, Mode mode) const {
+  switch (size) {
+  case 1:
+  case 2:
+  case 4:
+  case 8:
+    break;
+  default:
+    DS2LOG(Debug, "unsupported hardware watchpoint size %zu", size);
+    return kErrorInvalidArgument;
+  }
+
+  if (mode == kModeExec) {
+    // Hardware execute breakpoints live in a completely different register
+    // file (DBGBVR/DBGBCR) from data watchpoints (DBGWVR/DBGWCR), which is
+    // all this class programs; software breakpoints handle exec.
+    DS2LOG(Debug,
+           "hardware execute breakpoints are not supported through the ARM64 "
+           "watchpoint interface");
+    return kErrorUnsupported;
+  }
+
+  if ((mode & kModeExec) && (mode & (kModeRead | kModeWrite))) {
+    DS2LOG(Debug, "trying to set a hardware watchpoint with mixed exec and "
+                  "read/write modes");
+    return kErrorInvalidArgument;
+  }
+
+  uint64_t addr = address;
+  if ((addr & 0x7) + size > 8) {
+    DS2LOG(Debug,
+           "hardware watchpoint at %" PRI_PTR " of size %zu straddles more "
+           "than a single 8-byte watchpoint granule",
+           PRI_PTR_CAST(addr), size);
+    return kErrorInvalidArgument;
+  }
+
+  return super::isValid(address, size, mode);
+}
+
+#else // !ARCH_ARM64 (32-bit ARM)
 
 int HardwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
   return -1;
@@ -31,10 +107,6 @@ ErrorCode HardwareBreakpointManager::disableLocation(int idx,
   return kErrorUnsupported;
 }
 
-size_t HardwareBreakpointManager::maxWatchpoints() {
-  return _process->getMaxWatchpoints();
-}
-
 ErrorCode HardwareBreakpointManager::isValid(Address const &address,
                                              size_t size, Mode mode) const {
   DS2LOG(Debug, "Trying to set hardware breakpoint on arm");
@@ -44,5 +116,11 @@ ErrorCode HardwareBreakpointManager::isValid(Address const &address,
 size_t HardwareBreakpointManager::chooseBreakpointSize(Address const &) const {
   DS2BUG(
       "Choosing a hardware breakpoint size on ARM is an unsupported operation");
+}
+
+#endif // ARCH_ARM64
+
+size_t HardwareBreakpointManager::maxWatchpoints() {
+  return _process->getMaxWatchpoints();
 }
 } // namespace ds2

--- a/Sources/Core/Darwin/ARM64/HardwareBreakpointManager.cpp
+++ b/Sources/Core/Darwin/ARM64/HardwareBreakpointManager.cpp
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#include "DebugServer2/Core/HardwareBreakpointManager.h"
+
+namespace ds2 {
+
+// Real ARM64 hardware watchpoint support has only been implemented for
+// Linux (Sources/Core/Linux/ARM64/HardwareBreakpointManager.cpp) and Windows
+// (Sources/Core/Windows/ARM64/HardwareBreakpointManager.cpp) so far; Darwin
+// keeps the previous stub behavior. getMaxWatchpoints() is unimplemented for
+// this host too, so maxWatchpoints() (and therefore add()) already refuses
+// to enable any watchpoint before these would ever be reached.
+
+int HardwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
+  return -1;
+}
+
+ErrorCode HardwareBreakpointManager::enableLocation(Site const &site, int idx,
+                                                    Target::Thread *thread) {
+  return kErrorUnsupported;
+}
+
+ErrorCode HardwareBreakpointManager::disableLocation(int idx,
+                                                     Target::Thread *thread) {
+  return kErrorUnsupported;
+}
+
+} // namespace ds2

--- a/Sources/Core/FreeBSD/ARM64/HardwareBreakpointManager.cpp
+++ b/Sources/Core/FreeBSD/ARM64/HardwareBreakpointManager.cpp
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#include "DebugServer2/Core/HardwareBreakpointManager.h"
+
+namespace ds2 {
+
+// Real ARM64 hardware watchpoint support has only been implemented for
+// Linux (Sources/Core/Linux/ARM64/HardwareBreakpointManager.cpp) and Windows
+// (Sources/Core/Windows/ARM64/HardwareBreakpointManager.cpp) so far; FreeBSD
+// keeps the previous stub behavior. getMaxWatchpoints() is unimplemented for
+// this host too, so maxWatchpoints() (and therefore add()) already refuses
+// to enable any watchpoint before these would ever be reached.
+
+int HardwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
+  return -1;
+}
+
+ErrorCode HardwareBreakpointManager::enableLocation(Site const &site, int idx,
+                                                    Target::Thread *thread) {
+  return kErrorUnsupported;
+}
+
+ErrorCode HardwareBreakpointManager::disableLocation(int idx,
+                                                     Target::Thread *thread) {
+  return kErrorUnsupported;
+}
+
+} // namespace ds2

--- a/Sources/Core/Linux/ARM64/HardwareBreakpointManager.cpp
+++ b/Sources/Core/Linux/ARM64/HardwareBreakpointManager.cpp
@@ -1,0 +1,124 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#include "DebugServer2/Architecture/ARM64/HardwareWatchpoint.h"
+#include "DebugServer2/Core/HardwareBreakpointManager.h"
+#include "DebugServer2/Host/Linux/ExtraWrappers.h"
+#include "DebugServer2/Target/Process.h"
+#include "DebugServer2/Target/Thread.h"
+
+#include <csignal>
+
+namespace ds2 {
+
+//
+// Linux: DBGWVRn_EL1/DBGWCRn_EL1 are accessed via
+// PTRACE_GETREGSET/SETREGSET with NT_ARM_HW_WATCH (Host::Linux::PTrace
+// wraps this as readHardwareWatchpointControl()/writeHardwareWatchpointControl()).
+// There is no persistent "which watchpoint fired" status register on ARM64
+// (unlike x86's DR6): the kernel's hw_breakpoint subsystem does that
+// correlation for us and reports the exact faulting address via
+// siginfo_t::si_addr on the SIGTRAP, so hit() matches that address against
+// the enabled watchpoint ranges. This mirrors how lldb-server's own
+// NativeRegisterContextLinux_arm64dbreg/NativeRegisterContextDBReg
+// implementation determines the hit index from the other end of the wire.
+//
+
+ErrorCode HardwareBreakpointManager::enableLocation(Site const &site, int idx,
+                                                    Target::Thread *thread) {
+  uint64_t wvr;
+  uint32_t wcr;
+  CHK(ComputeARM64WatchpointControl(site.address, site.size, site.mode, wvr,
+                                    wcr));
+
+  Target::Process *process = thread->process();
+  ProcessThreadId ptid(process->pid(), thread->tid());
+
+  std::vector<uint64_t> addresses;
+  std::vector<uint32_t> controls;
+  CHK(process->ptrace().readHardwareWatchpointControl(ptid, addresses,
+                                                       controls));
+
+  if (static_cast<size_t>(idx) >= addresses.size()) {
+    return kErrorInvalidArgument;
+  }
+
+  addresses[idx] = wvr;
+  controls[idx] = wcr;
+
+  return process->ptrace().writeHardwareWatchpointControl(ptid, addresses,
+                                                           controls);
+}
+
+ErrorCode HardwareBreakpointManager::disableLocation(int idx,
+                                                     Target::Thread *thread) {
+  Target::Process *process = thread->process();
+  ProcessThreadId ptid(process->pid(), thread->tid());
+
+  std::vector<uint64_t> addresses;
+  std::vector<uint32_t> controls;
+  CHK(process->ptrace().readHardwareWatchpointControl(ptid, addresses,
+                                                       controls));
+
+  if (static_cast<size_t>(idx) >= addresses.size()) {
+    return kErrorInvalidArgument;
+  }
+
+  addresses[idx] = 0;
+  controls[idx] = 0;
+
+  return process->ptrace().writeHardwareWatchpointControl(ptid, addresses,
+                                                           controls);
+}
+
+int HardwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
+  if (_sites.empty()) {
+    return -1;
+  }
+
+  if (thread->state() != Target::Thread::kStopped) {
+    return -1;
+  }
+
+  Target::Process *process = thread->process();
+  ProcessThreadId ptid(process->pid(), thread->tid());
+
+  siginfo_t si;
+  if (process->ptrace().getSigInfo(ptid, si) != kSuccess) {
+    return -1;
+  }
+
+  if (si.si_code != TRAP_HWBKPT) {
+    return -1;
+  }
+
+  uint64_t addr = reinterpret_cast<uint64_t>(si.si_addr);
+  for (size_t i = 0; i < _locations.size(); ++i) {
+    if (_locations[i] == 0) {
+      continue;
+    }
+
+    auto it = _sites.find(_locations[i]);
+    if (it == _sites.end()) {
+      continue;
+    }
+
+    Site const &s = it->second;
+    if (addr >= static_cast<uint64_t>(s.address) &&
+        addr < static_cast<uint64_t>(s.address) + s.size) {
+      site = s;
+      return static_cast<int>(i);
+    }
+  }
+
+  return -1;
+}
+
+} // namespace ds2

--- a/Sources/Core/Windows/ARM64/HardwareBreakpointManager.cpp
+++ b/Sources/Core/Windows/ARM64/HardwareBreakpointManager.cpp
@@ -1,0 +1,216 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#include "DebugServer2/Architecture/ARM64/HardwareWatchpoint.h"
+#include "DebugServer2/Core/HardwareBreakpointManager.h"
+#include "DebugServer2/Target/Process.h"
+#include "DebugServer2/Target/Windows/Thread.h"
+#include "DebugServer2/Utils/Log.h"
+
+namespace ds2 {
+
+//
+// Windows: hardware watchpoints are exposed via Wcr[]/Wvr[] in
+// CONTEXT_DEBUG_REGISTERS, read/written through
+// Target::Windows::Thread::{read,write}WatchpointRegisters().
+//
+// Unlike x86 (which has DR6, a persistent "which register fired" status
+// register), the ARM64 ARM_NT_CONTEXT exposes no equivalent for
+// watchpoints, and (as far as could be determined without access to real
+// ARM64 hardware/kernel documentation) neither does the EXCEPTION_RECORD
+// delivered for the resulting STATUS_SINGLE_STEP. This is a known
+// limitation: when exactly one watchpoint is armed, hit() can unambiguously
+// report it; with more than one simultaneously-armed watchpoint, there is no
+// documented way found here to determine which slot actually trapped, and
+// this code falls back to reporting the last enabled slot with a logged
+// warning. This should be revisited against real Windows ARM64 hardware
+// (notably, whether EXCEPTION_RECORD::ExceptionInformation carries a fault
+// address for this exception the way it does for STATUS_ACCESS_VIOLATION).
+//
+// Sources/Target/Windows/Thread.cpp calls fillStopInfo() (and therefore
+// hit()) for both STATUS_BREAKPOINT and STATUS_SINGLE_STEP, so hit() must
+// rule out stops that cannot possibly be this watchpoint firing before
+// picking a slot:
+//
+//   - STATUS_BREAKPOINT is a software breakpoint (a BRK instruction trap);
+//     ARM64 watchpoints only ever deliver as STATUS_SINGLE_STEP, so this
+//     can never be a watchpoint.
+//   - STATUS_SINGLE_STEP for a stop Thread::step() itself requested (see
+//     Thread::wasExplicitStep()) is ambiguous rather than ruled out: the
+//     stepped instruction may or may not have also touched a watched byte,
+//     and Windows gives no way to tell from the exception alone (PSTATE.SS
+//     cannot be used either: the architectural software-step exception
+//     transition clears it before the stopped context can be read,
+//     regardless of cause). _lastKnownValues resolves this by comparing
+//     each enabled watchpoint's memory against what it held when last
+//     checked; whichever one changed is the hit, and if none did, this was
+//     an ordinary step. This can only ever confirm a write/access
+//     watchpoint this way, not a pure read watchpoint (reading doesn't
+//     change the value), which is a known gap in this specific ambiguous
+//     case.
+//
+
+ErrorCode HardwareBreakpointManager::enableLocation(Site const &site, int idx,
+                                                    Target::Thread *thread) {
+  uint64_t wvr;
+  uint32_t wcr;
+  CHK(ComputeARM64WatchpointControl(site.address, site.size, site.mode, wvr,
+                                    wcr));
+
+  std::vector<uint64_t> addresses;
+  std::vector<uint32_t> controls;
+  CHK(thread->readWatchpointRegisters(addresses, controls));
+
+  if (static_cast<size_t>(idx) >= addresses.size()) {
+    return kErrorInvalidArgument;
+  }
+
+  addresses[idx] = wvr;
+  controls[idx] = wcr;
+
+  CHK(thread->writeWatchpointRegisters(addresses, controls));
+
+  // Seed the value cache hit() uses to disambiguate an explicit step from
+  // a watchpoint hit (see the file comment above). Best-effort: if the
+  // range can't be read right now (e.g. not yet mapped), just leave this
+  // slot without a cached value rather than an outdated one; hit() skips
+  // slots it has no cached value for.
+  ByteVector value;
+  if (thread->process()->readMemoryBuffer(site.address, site.size, value) ==
+      kSuccess) {
+    _lastKnownValues[idx] = std::move(value);
+  } else {
+    _lastKnownValues.erase(idx);
+  }
+
+  return kSuccess;
+}
+
+ErrorCode HardwareBreakpointManager::disableLocation(int idx,
+                                                     Target::Thread *thread) {
+  std::vector<uint64_t> addresses;
+  std::vector<uint32_t> controls;
+  CHK(thread->readWatchpointRegisters(addresses, controls));
+
+  if (static_cast<size_t>(idx) >= addresses.size()) {
+    return kErrorInvalidArgument;
+  }
+
+  addresses[idx] = 0;
+  controls[idx] = 0;
+
+  CHK(thread->writeWatchpointRegisters(addresses, controls));
+  _lastKnownValues.erase(idx);
+  return kSuccess;
+}
+
+int HardwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
+  if (_sites.empty()) {
+    return -1;
+  }
+
+  if (thread->state() != Target::Thread::kStopped) {
+    return -1;
+  }
+
+  auto *winThread = static_cast<Target::Windows::Thread *>(thread);
+  bool ambiguousStep = false;
+  switch (winThread->lastExceptionCode()) {
+  case STATUS_BREAKPOINT:
+    // Never a watchpoint; see the file comment above.
+    return -1;
+
+  case STATUS_SINGLE_STEP:
+    ambiguousStep = winThread->wasExplicitStep();
+    break;
+
+  default:
+    break;
+  }
+
+  if (ambiguousStep) {
+    // Thread::step() itself requested this stop; find whichever enabled
+    // watchpoint's memory actually changed, if any (see the file comment
+    // above).
+    for (size_t i = 0; i < _locations.size(); ++i) {
+      if (_locations[i] == 0) {
+        continue;
+      }
+
+      auto siteIt = _sites.find(_locations[i]);
+      if (siteIt == _sites.end()) {
+        continue;
+      }
+
+      auto cacheIt = _lastKnownValues.find(static_cast<int>(i));
+      if (cacheIt == _lastKnownValues.end()) {
+        continue;
+      }
+
+      ByteVector current;
+      if (thread->process()->readMemoryBuffer(
+              siteIt->second.address, siteIt->second.size, current) !=
+          kSuccess) {
+        continue;
+      }
+
+      if (current != cacheIt->second) {
+        cacheIt->second = std::move(current);
+        site = siteIt->second;
+        return static_cast<int>(i);
+      }
+    }
+
+    // No enabled watchpoint's memory changed: the ordinary completion of
+    // the requested step, not a watchpoint.
+    return -1;
+  }
+
+  int hitIdx = -1;
+  int enabledCount = 0;
+  for (size_t i = 0; i < _locations.size(); ++i) {
+    if (_locations[i] == 0) {
+      continue;
+    }
+
+    auto it = _sites.find(_locations[i]);
+    if (it == _sites.end()) {
+      continue;
+    }
+
+    ++enabledCount;
+    hitIdx = static_cast<int>(i);
+  }
+
+  if (hitIdx < 0) {
+    return -1;
+  }
+
+  if (enabledCount > 1) {
+    DS2LOG(Warning,
+           "%d hardware watchpoints are armed; Windows ARM64 cannot "
+           "determine which one actually trapped, reporting slot %d",
+           enabledCount, hitIdx);
+  }
+
+  site = _sites.find(_locations[hitIdx])->second;
+
+  // Refresh the cached value for the reported slot so a later explicit-step
+  // comparison (see above) starts from an accurate baseline.
+  ByteVector current;
+  if (thread->process()->readMemoryBuffer(site.address, site.size, current) ==
+      kSuccess) {
+    _lastKnownValues[hitIdx] = std::move(current);
+  }
+
+  return hitIdx;
+}
+
+} // namespace ds2

--- a/Sources/Host/Linux/ARM64/PTraceARM64.cpp
+++ b/Sources/Host/Linux/ARM64/PTraceARM64.cpp
@@ -12,7 +12,10 @@
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"
 #include "DebugServer2/Host/Platform.h"
 
+#include <algorithm>
 #include <asm/ptrace.h>
+#include <cstddef>
+#include <cstring>
 #include <elf.h>
 #include <sys/ptrace.h>
 #include <sys/uio.h>
@@ -23,6 +26,16 @@ namespace ds2 {
 namespace Host {
 namespace Linux {
 
+namespace {
+// The lowest DEBUG_ARCH value that implements the self-hosted debug
+// register interface (NT_ARM_HW_BREAK/NT_ARM_HW_WATCH) this code relies on,
+// introduced with ARMv8-A. Later architecture revisions (ARMv8.1 and
+// beyond) report higher DEBUG_ARCH values here but remain backward
+// compatible with this same register interface, so they should be accepted
+// too rather than treated as unsupported.
+constexpr uint32_t kMinDebugArch = 0x06;
+}
+
 int PTrace::getMaxStoppoints(ProcessThreadId const &ptid, int regSet) {
   // Retrieve the information about Hardware Breakpoint, if supported.
   // user_hwdebug_state.dbg_info is formatted as follows:
@@ -32,10 +45,20 @@ int PTrace::getMaxStoppoints(ProcessThreadId const &ptid, int regSet) {
   // |   RESERVED    |   RESERVED   |   DEBUG_ARCH  |  NUM_SLOTS    |
   // +---------------+--------------+---------------+---------------+
   //
-  // DEBUG_ARCH should be 0x06 for aarch64-armv8a.
+  // Deliberately do not go through readRegisterSet(): it DS2ASSERTs that the
+  // kernel returns exactly as many bytes as were requested, but on real
+  // hardware implementing fewer than the architectural 16 slots the kernel
+  // shortens the note to just the implemented slots, which is shorter than
+  // sizeof(drs) whenever fewer than 16 slots are implemented (the common
+  // case in practice; see readHardwareWatchpointControl() below for the
+  // same accommodation).
   struct user_hwdebug_state drs;
-  if (readRegisterSet(ptid, regSet, &drs, sizeof(drs)) != kSuccess ||
-      ((drs.dbg_info >> 8) & 0xff) != 0x06) {
+  std::memset(&drs, 0, sizeof(drs));
+
+  struct iovec iov = {&drs, sizeof(drs)};
+  if (wrapPtrace(PTRACE_GETREGSET, ptid.validTid() ? ptid.tid : ptid.pid,
+                regSet, &iov) < 0 ||
+      ((drs.dbg_info >> 8) & 0xff) < kMinDebugArch) {
     return 0;
   }
 
@@ -48,6 +71,83 @@ int PTrace::getMaxHardwareBreakpoints(ProcessThreadId const &ptid) {
 
 int PTrace::getMaxHardwareWatchpoints(ProcessThreadId const &ptid) {
   return getMaxStoppoints(ptid, NT_ARM_HW_WATCH);
+}
+
+ErrorCode PTrace::readHardwareWatchpointControl(
+    ProcessThreadId const &ptid, std::vector<uint64_t> &addresses,
+    std::vector<uint32_t> &controls) {
+  struct user_hwdebug_state state;
+  std::memset(&state, 0, sizeof(state));
+
+  // Deliberately do not go through the shared readRegisterSet() helper here:
+  // it DS2ASSERTs that the kernel returns exactly as many bytes as were
+  // requested, but the kernel only ever fills in
+  // offsetof(dbg_regs) + (dbg_info & 0xff) * sizeof(dbg_regs[0]) bytes of
+  // this note -- i.e. exactly the number of watchpoints the target actually
+  // implements, which on real hardware is almost always fewer than
+  // array_sizeof(state.dbg_regs) (architecturally up to 16, but most cores
+  // implement 2-6). Requesting the full 16-slot struct is intentional (it's
+  // the only way to size a buffer without already knowing the count), so
+  // that mismatch is expected, not an error.
+  int regSet = NT_ARM_HW_WATCH;
+  struct iovec iov = {&state, sizeof(state)};
+  if (wrapPtrace(PTRACE_GETREGSET,
+                ptid.validTid() ? ptid.tid : ptid.pid, regSet, &iov) < 0) {
+    return Platform::TranslateError();
+  }
+
+  if (((state.dbg_info >> 8) & 0xff) < kMinDebugArch) {
+    // Unsupported (pre-ARMv8-A) debug architecture; treat as "no
+    // watchpoints available" rather than handing back (possibly
+    // meaningless) register contents.
+    addresses.clear();
+    controls.clear();
+    return kSuccess;
+  }
+
+  size_t count = std::min<size_t>(state.dbg_info & 0xff,
+                                  array_sizeof(state.dbg_regs));
+
+  // Do not read past what the kernel actually populated (see above).
+  size_t regsOffset = offsetof(struct user_hwdebug_state, dbg_regs);
+  size_t available =
+      iov.iov_len > regsOffset
+          ? (iov.iov_len - regsOffset) / sizeof(state.dbg_regs[0])
+          : 0;
+  count = std::min(count, available);
+
+  addresses.resize(count);
+  controls.resize(count);
+  for (size_t i = 0; i < count; ++i) {
+    addresses[i] = state.dbg_regs[i].addr;
+    controls[i] = state.dbg_regs[i].ctrl;
+  }
+
+  return kSuccess;
+}
+
+ErrorCode PTrace::writeHardwareWatchpointControl(
+    ProcessThreadId const &ptid, std::vector<uint64_t> const &addresses,
+    std::vector<uint32_t> const &controls) {
+  DS2ASSERT(addresses.size() == controls.size());
+
+  struct user_hwdebug_state state;
+  std::memset(&state, 0, sizeof(state));
+
+  size_t count =
+      std::min(addresses.size(), array_sizeof(state.dbg_regs));
+  for (size_t i = 0; i < count; ++i) {
+    state.dbg_regs[i].addr = addresses[i];
+    state.dbg_regs[i].ctrl = controls[i];
+  }
+
+  // Only claim to write as many registers as the caller supplied (which
+  // should always be exactly what readHardwareWatchpointControl() reported
+  // as supported); the kernel's SETREGSET handler expects the note to be
+  // sized for the number of debug registers it implements.
+  size_t length = offsetof(struct user_hwdebug_state, dbg_regs) +
+                  count * sizeof(state.dbg_regs[0]);
+  return writeRegisterSet(ptid, NT_ARM_HW_WATCH, &state, length);
 }
 
 ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid,

--- a/Sources/Target/Linux/ARM64/ProcessARM64.cpp
+++ b/Sources/Target/Linux/ARM64/ProcessARM64.cpp
@@ -56,6 +56,14 @@ ErrorCode Process::allocateMemory(size_t size, uint32_t protection,
 ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
   return kErrorUnsupported;
 }
+
+int Process::getMaxBreakpoints() const {
+  return ptrace().getMaxHardwareBreakpoints(_pid);
+}
+
+int Process::getMaxWatchpoints() const {
+  return ptrace().getMaxHardwareWatchpoints(_pid);
+}
 } // namespace Linux
 } // namespace Target
 } // namespace ds2

--- a/Sources/Target/Windows/ARM64/ThreadARM64.cpp
+++ b/Sources/Target/Windows/ARM64/ThreadARM64.cpp
@@ -15,6 +15,8 @@
 #include "DebugServer2/Utils/Log.h"
 
 #include <cstring>
+#include <iterator>
+#include <vector>
 #include <windows.h>
 
 using ds2::Host::Platform;
@@ -23,20 +25,12 @@ namespace ds2 {
 namespace Target {
 namespace Windows {
 
-namespace {
-// PSTATE.SS, per the ARMv8 architecture reference manual. Setting this bit
-// in Cpsr and resuming the thread arms a single hardware step: the kernel
-// arms and disarms the underlying MDSCR_EL1 trap transparently, the same way
-// it already does for EFLAGS.TF on x86, so no separate debug register access
-// is required from user mode.
-constexpr uint64_t kPSTATE_SS = 1ULL << 21;
-}
-
 ErrorCode Thread::step(int signal, Address const &address) {
   CHK(modifyRegisters([](Architecture::CPUState &state) {
     state.state64.gp.cpsr |= kPSTATE_SS;
   }));
 
+  setExplicitStep();
   return resume(signal, address);
 }
 
@@ -100,6 +94,46 @@ ErrorCode Thread::writeCPUState(Architecture::CPUState const &state) {
 
   BOOL result = SetThreadContext(_handle, &context);
   if (!result) {
+    return Platform::TranslateError();
+  }
+
+  return kSuccess;
+}
+
+ErrorCode Thread::readWatchpointRegisters(std::vector<uint64_t> &addresses,
+                                          std::vector<uint32_t> &controls) {
+  CONTEXT context;
+
+  std::memset(&context, 0, sizeof(context));
+  context.ContextFlags = CONTEXT_CONTROL | CONTEXT_DEBUG_REGISTERS;
+
+  if (!GetThreadContext(_handle, &context)) {
+    return Platform::TranslateError();
+  }
+
+  addresses.assign(std::begin(context.Wvr), std::end(context.Wvr));
+  controls.assign(std::begin(context.Wcr), std::end(context.Wcr));
+
+  return kSuccess;
+}
+
+ErrorCode
+Thread::writeWatchpointRegisters(std::vector<uint64_t> const &addresses,
+                                 std::vector<uint32_t> const &controls) {
+  DS2ASSERT(addresses.size() == controls.size());
+  DS2ASSERT(addresses.size() <= ARM64_MAX_WATCHPOINTS);
+
+  CONTEXT context;
+
+  std::memset(&context, 0, sizeof(context));
+  context.ContextFlags = CONTEXT_DEBUG_REGISTERS;
+
+  for (size_t i = 0; i < addresses.size(); ++i) {
+    context.Wvr[i] = addresses[i];
+    context.Wcr[i] = controls[i];
+  }
+
+  if (!SetThreadContext(_handle, &context)) {
     return Platform::TranslateError();
   }
 

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -271,9 +271,16 @@ ErrorCode Process::wait() {
     case EXCEPTION_DEBUG_EVENT: {
       // First-chance exceptions may yet be caught by the debugee, so don't
       // break for them. Breakpoints can never be handled by the inferior, so
-      // ignore here.
+      // ignore here. Hardware breakpoints/watchpoints also always arrive as
+      // STATUS_SINGLE_STEP on Windows (see Thread::updateState()), not
+      // STATUS_BREAKPOINT, so the same reasoning applies to it: continuing
+      // it first-chance would hand the trap to the debugee's own VEH/SEH
+      // handlers before Thread::updateState()/hit() ever classify it,
+      // letting a handler silently consume it and, even when unhandled,
+      // delaying detection until second chance.
       auto code = de.u.Exception.ExceptionRecord.ExceptionCode;
-      if (de.u.Exception.dwFirstChance && code != STATUS_BREAKPOINT) {
+      if (de.u.Exception.dwFirstChance && code != STATUS_BREAKPOINT &&
+          code != STATUS_SINGLE_STEP) {
         DS2LOG(Error,
                "Ignoring first-chance exception and continuing; code: %s",
                Stringify::ExceptionCode(
@@ -586,6 +593,15 @@ ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
 
   return kSuccess;
 }
+
+#if defined(ARCH_ARM64)
+int Process::getMaxWatchpoints() const {
+  // Architecturally ARM64 allows up to 16 watchpoints, but Windows only
+  // tracks/exposes ARM64_MAX_WATCHPOINTS (2) worth of Wcr/Wvr slots in
+  // CONTEXT_DEBUG_REGISTERS; see winnt.h.
+  return ARM64_MAX_WATCHPOINTS;
+}
+#endif
 
 ErrorCode Process::enumerateSharedLibraries(
     std::function<void(SharedLibraryInfo const &)> const &cb) {

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -121,6 +121,11 @@ void Thread::updateState(DEBUG_EVENT const &de) {
   switch (de.dwDebugEventCode) {
   case EXCEPTION_DEBUG_EVENT:
     _state = kStopped;
+    _lastExceptionCode = de.u.Exception.ExceptionRecord.ExceptionCode;
+#if defined(ARCH_ARM64)
+    _wasExplicitStep = _explicitStep;
+    _explicitStep = false;
+#endif
 
     DS2LOG(
         Debug,


### PR DESCRIPTION
Covers Linux (PTRACE_GETREGSET/SETREGSET with NT_ARM_HW_WATCH) and Windows (Wvr[]/Wcr[] in CONTEXT_DEBUG_REGISTERS). Hardware execute breakpoints are unaffected: those stay on SoftwareBreakpointManager, a completely separate register file (DBGBVR/DBGBCR) from watchpoints (DBGWVR/DBGWCR).

The OS-specific register access and hit-detection logic (enableLocation/disableLocation/hit) lives in its own file per OS, following the same Host/<OS>/<Arch> and Target/<OS>/<Arch> split used elsewhere in the tree, rather than branching on OS_LINUX/OS_WIN32 inside a single Core/ARM file:

  - Sources/Core/Linux/ARM64/HardwareBreakpointManager.cpp
  - Sources/Core/Windows/ARM64/HardwareBreakpointManager.cpp
  - Sources/Core/Darwin/ARM64/HardwareBreakpointManager.cpp (stub)
  - Sources/Core/FreeBSD/ARM64/HardwareBreakpointManager.cpp (stub)

getMaxWatchpoints() is unimplemented on Darwin/FreeBSD, so maxWatchpoints() (and therefore add()) already refuses to enable any watchpoint on those hosts before the stub methods would ever be reached. They exist only so the class links there like everywhere else, without an OS check standing in for a missing per-OS file.

Sources/Core/ARM/HardwareBreakpointManager.cpp keeps only what doesn't depend on the host OS: size/mode validation, the 32-bit ARM stub, and maxWatchpoints(). No OS conditionals remain in it at all. The DBGWCRn_EL1/Wcr bit-layout helper shared by the Linux and Windows files moves to a header
(Headers/DebugServer2/Architecture/ARM64/HardwareWatchpoint.h) so there's a single definition instead of duplicating it per file.