### PR TITLE
GHA: cancel superseded runs on the same ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   LLVM_REF: ec450b19004a653f3db3ad50e88fbf6529a9d841
   SCCACHE_DIRECT: 'true'


### PR DESCRIPTION
A new push to a PR currently lets its previous CI run keep going to completion alongside the new one, burning runner time on results that are about to be superseded.

Key the group by PR number rather than github.head_ref: head_ref is just the source branch name, not repo- or PR-unique, so two open PRs from different forks sharing a branch name (e.g. both named "main") would land in the same concurrency group and cancel each other's runs instead of only their own.