### PR TITLE
GHA: build and test Android with the latest NDK instead of the default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -383,14 +383,17 @@ jobs:
       - name: Install Build Tools
         run: choco install winflexbison3
 
-      # cmake finds the Android NDK from ANDROID_NDK in the environment, which
-      # is pre-installed and configured in the Windows runner image.
+      # The Windows runner image ships several NDK versions side by side
+      # (ANDROID_NDK/ANDROID_NDK_HOME point at an older default); pin to
+      # ANDROID_NDK_LATEST_HOME explicitly so ds2 is built with the same NDK
+      # release used to compile the lldb test inferiors in test-android.
       - name: Configure
         run: |
           cmake -B ${{ github.workspace }}/BinaryCache/ds2 `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_SYSTEM_NAME=Android `
                 -D CMAKE_ANDROID_ARCH_ABI=${{ matrix.abi }} `
+                -D CMAKE_ANDROID_NDK="$($env:ANDROID_NDK_LATEST_HOME -replace '\\', '/')" `
                 -D DS2_REGSGEN2=${{ github.workspace }}/BinaryCache/RegsGen2/Release/regsgen2.exe `
                 -G Ninja
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -392,7 +392,7 @@ jobs:
             --platform-name remote-android
             --platform-url connect://localhost:5432
             --platform-working-dir /data/local/tmp
-            --compiler=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android28-clang
+            --compiler=$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android28-clang
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/ds2/android-x86_64.excluded
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/android-x86_64.excluded
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/non-debugserver-tests.excluded
@@ -496,7 +496,7 @@ jobs:
             --platform-name remote-android
             --platform-url connect://localhost:5432
             --platform-working-dir /data/local/tmp
-            --compiler=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android27-clang
+            --compiler=$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android27-clang
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/ds2/android-aarch64.excluded
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/android-aarch64.excluded
             --excluded ${{ github.workspace }}/SourceCache/ds2/Support/Testing/Excluded/upstream/non-debugserver-tests.excluded


### PR DESCRIPTION
The runner images carry three NDK releases side by side and point `ANDROID_NDK`/`ANDROID_NDK_HOME` at the oldest one by default; `ANDROID_NDK_LATEST_HOME` is the only one of the three that tracks the newest available release.