### PR TITLE
GHA: drop the per-arch *-status jobs from test-*.yml

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -125,15 +125,6 @@ jobs:
             1>/dev/null 2>/tmp/dotest-android-x86_64.log;
             rc=$?; grep -v '^UNSUPPORTED: LLDB ' /tmp/dotest-android-x86_64.log; exit $rc
 
-  test-android-x86_64-status:
-    needs: [test-android-x86_64]
-    if: always()
-    runs-on: ubuntu-latest
-    name: Test Android x86_64 (status)
-    steps:
-      - if: needs.test-android-x86_64.result != 'success'
-        run: exit 1
-
   # Run a small sub-set of tests on arm64. The emulator is very slow so it is
   # not practical to run more tests until we can run on an arm64 runner with
   # virtualization. Only one category runs here, so this already reports as

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -24,10 +24,7 @@ jobs:
   # into a single collapsible entry in the PR checks list, which is what
   # actually fixes the one-check-per-category-per-arch clutter -- varying the
   # name per category is what defeats that grouping and is why each category
-  # showed up as its own separate, differently-named check before. The
-  # *-status job per arch gives branch protection one plain, matrix-independent
-  # check name to require rather than depending on how that grouping is
-  # surfaced there.
+  # showed up as its own separate, differently-named check before.
 
   test-linux-i686:
     runs-on: ubuntu-latest
@@ -89,15 +86,6 @@ jobs:
           working-dir: ${{ github.workspace }}/temp
           test-subdirs: ${{ steps.test-subdirs.outputs.dirs }}
 
-  test-linux-i686-status:
-    needs: [test-linux-i686]
-    if: always()
-    runs-on: ubuntu-latest
-    name: Test Linux i686 (status)
-    steps:
-      - if: needs.test-linux-i686.result != 'success'
-        run: exit 1
-
   test-linux-x86_64:
     runs-on: ubuntu-latest
     name: Test Linux x86_64
@@ -149,15 +137,6 @@ jobs:
           working-dir: ${{ github.workspace }}/temp
           test-subdirs: ${{ steps.test-subdirs.outputs.dirs }}
 
-  test-linux-x86_64-status:
-    needs: [test-linux-x86_64]
-    if: always()
-    runs-on: ubuntu-latest
-    name: Test Linux x86_64 (status)
-    steps:
-      - if: needs.test-linux-x86_64.result != 'success'
-        run: exit 1
-
   test-linux-aarch64:
     runs-on: ubuntu-24.04-arm
     name: Test Linux aarch64
@@ -208,12 +187,3 @@ jobs:
           platform: linux
           working-dir: ${{ github.workspace }}/temp
           test-subdirs: ${{ steps.test-subdirs.outputs.dirs }}
-
-  test-linux-aarch64-status:
-    needs: [test-linux-aarch64]
-    if: always()
-    runs-on: ubuntu-latest
-    name: Test Linux aarch64 (status)
-    steps:
-      - if: needs.test-linux-aarch64.result != 'success'
-        run: exit 1


### PR DESCRIPTION
Branch protection on this repo only requires the overall workflow run to pass, not any specific named check, so the *-status jobs added no protection value: a matrix sub-job failing already flips the run's conclusion to failure, and the sub-job's own entry in the checks list already identifies which test failed.

test-windows.yml doesn't exist yet at this point in history; its own status jobs get dropped when that file is created further up the stack.